### PR TITLE
chore: check for windows safe dir

### DIFF
--- a/workflow-steps/checkout/main.ts
+++ b/workflow-steps/checkout/main.ts
@@ -9,7 +9,9 @@ const fetchTags = process.env.GIT_FETCH_TAGS === 'true';
 // TODO: infer this in cases where the NX_BRANCH is a branch name despite being a PR (certain CI providers, not GitHub)
 const isPR = !isNaN(parseInt(nxBranch!));
 
-execSync(`git config --global --add safe.directory /home/workflows/workspace`);
+if (process.platform != 'win32') {
+  execSync(`git config --global --add safe.directory /home/workflows/workspace`);
+}
 execSync('git init .');
 execSync(`git remote add origin ${repoUrl}`);
 

--- a/workflow-steps/checkout/output/main.js
+++ b/workflow-steps/checkout/output/main.js
@@ -6,7 +6,9 @@ var nxBranch = process.env.NX_BRANCH;
 var depth = process.env.GIT_CHECKOUT_DEPTH || 1;
 var fetchTags = process.env.GIT_FETCH_TAGS === "true";
 var isPR = !isNaN(parseInt(nxBranch));
-(0, import_child_process.execSync)(`git config --global --add safe.directory /home/workflows/workspace`);
+if (process.platform != "win32") {
+  (0, import_child_process.execSync)(`git config --global --add safe.directory /home/workflows/workspace`);
+}
 (0, import_child_process.execSync)("git init .");
 (0, import_child_process.execSync)(`git remote add origin ${repoUrl}`);
 if (depth === "0") {


### PR DESCRIPTION
Allow this action to support git on windows by checking the platform and not setting the safeDir for the case of windows.

The expectation is that the user has already set their directory as safe, which is something we will do ourselves.