### PR TITLE
fix: re-adding remember value

### DIFF
--- a/workflow-steps/cache/main.ts
+++ b/workflow-steps/cache/main.ts
@@ -3,7 +3,7 @@ import { createConnectTransport } from '@bufbuild/connect-web';
 import { CacheService } from './generated_protos/cache_connect';
 import { RestoreRequest, RestoreResponse } from './generated_protos/cache_pb';
 import { hashKey } from './hashing-utils';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { appendFileSync, writeFileSync, existsSync } from 'fs';
 
 export const cacheClient = createPromiseClient(
   CacheService,
@@ -31,7 +31,7 @@ cacheClient
   .then((resp: RestoreResponse) => {
     if (resp.success) {
       console.log('Found cache entry under key: ' + resp.key);
-      // rememberCacheRestorationForPostStep();
+      rememberCacheRestorationForPostStep();
     } else {
       console.log('Cache miss.');
     }
@@ -40,15 +40,14 @@ cacheClient
 function rememberCacheRestorationForPostStep() {
   try {
     if (existsSync(process.env.NX_CLOUD_ENV)) {
-      const nxCloudEnv = readFileSync(process.env.NX_CLOUD_ENV).toString();
-      writeFileSync(
+      appendFileSync(
         process.env.NX_CLOUD_ENV,
-        `${nxCloudEnv}\nNX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true`,
+        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true\n`,
       );
     } else {
       writeFileSync(
         process.env.NX_CLOUD_ENV,
-        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true`,
+        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true\n`,
       );
     }
   } catch (e) {

--- a/workflow-steps/cache/output/main.js
+++ b/workflow-steps/cache/output/main.js
@@ -530,12 +530,12 @@ var require_minimatch = __commonJS({
   "../../node_modules/minimatch/minimatch.js"(exports, module2) {
     module2.exports = minimatch;
     minimatch.Minimatch = Minimatch;
-    var path = function() {
+    var path = (() => {
       try {
         return require("path");
       } catch (e) {
       }
-    }() || {
+    })() || {
       sep: "/"
     };
     minimatch.sep = path.sep;
@@ -568,8 +568,9 @@ var require_minimatch = __commonJS({
       };
     }
     function ext(a, b) {
+      a = a || {};
       b = b || {};
-      var t = {};
+      const t = {};
       Object.keys(a).forEach(function(k) {
         t[k] = a[k];
       });
@@ -582,14 +583,14 @@ var require_minimatch = __commonJS({
       if (!def || typeof def !== "object" || !Object.keys(def).length) {
         return minimatch;
       }
-      var orig = minimatch;
-      var m = function minimatch2(p, pattern, options) {
+      const orig = minimatch;
+      const m = function minimatch2(p, pattern, options) {
         return orig(p, pattern, ext(def, options));
       };
       m.Minimatch = function Minimatch2(pattern, options) {
         return new orig.Minimatch(pattern, ext(def, options));
       };
-      m.Minimatch.defaults = function defaults(options) {
+      m.Minimatch.defaults = (options) => {
         return orig.defaults(ext(def, options)).Minimatch;
       };
       m.filter = function filter2(pattern, options) {
@@ -619,6 +620,8 @@ var require_minimatch = __commonJS({
       if (!options.nocomment && pattern.charAt(0) === "#") {
         return false;
       }
+      if (pattern.trim() === "")
+        return p === "";
       return new Minimatch(pattern, options).match(p);
     }
     function Minimatch(pattern, options) {
@@ -629,7 +632,7 @@ var require_minimatch = __commonJS({
       if (!options)
         options = {};
       pattern = pattern.trim();
-      if (!options.allowWindowsEscape && path.sep !== "/") {
+      if (path.sep !== "/") {
         pattern = pattern.split(path.sep).join("/");
       }
       this.options = options;
@@ -639,13 +642,14 @@ var require_minimatch = __commonJS({
       this.negate = false;
       this.comment = false;
       this.empty = false;
-      this.partial = !!options.partial;
       this.make();
     }
     Minimatch.prototype.debug = function() {
     };
     Minimatch.prototype.make = make;
     function make() {
+      if (this._made)
+        return;
       var pattern = this.pattern;
       var options = this.options;
       if (!options.nocomment && pattern.charAt(0) === "#") {
@@ -659,9 +663,7 @@ var require_minimatch = __commonJS({
       this.parseNegate();
       var set = this.globSet = this.braceExpand();
       if (options.debug)
-        this.debug = function debug() {
-          console.error.apply(console, arguments);
-        };
+        this.debug = console.error;
       this.debug(this.pattern, set);
       set = this.globParts = set.map(function(s) {
         return s.split(slashSplit);
@@ -713,7 +715,7 @@ var require_minimatch = __commonJS({
       return expand(pattern);
     }
     var MAX_PATTERN_LENGTH = 1024 * 64;
-    var assertValidPattern = function(pattern) {
+    var assertValidPattern = (pattern) => {
       if (typeof pattern !== "string") {
         throw new TypeError("invalid pattern");
       }
@@ -726,16 +728,12 @@ var require_minimatch = __commonJS({
     function parse(pattern, isSub) {
       assertValidPattern(pattern);
       var options = this.options;
-      if (pattern === "**") {
-        if (!options.noglobstar)
-          return GLOBSTAR;
-        else
-          pattern = "*";
-      }
+      if (!options.noglobstar && pattern === "**")
+        return GLOBSTAR;
       if (pattern === "")
         return "";
       var re = "";
-      var hasMagic = !!options.nocase;
+      var hasMagic = false;
       var escaping = false;
       var patternListStack = [];
       var negativeLists = [];
@@ -858,15 +856,17 @@ var require_minimatch = __commonJS({
               escaping = false;
               continue;
             }
-            var cs = pattern.substring(classStart + 1, i);
-            try {
-              RegExp("[" + cs + "]");
-            } catch (er) {
-              var sp = this.parse(cs, SUBPARSE);
-              re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
-              hasMagic = hasMagic || sp[1];
-              inClass = false;
-              continue;
+            if (inClass) {
+              var cs = pattern.substring(classStart + 1, i);
+              try {
+                RegExp("[" + cs + "]");
+              } catch (er) {
+                var sp = this.parse(cs, SUBPARSE);
+                re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
+                hasMagic = hasMagic || sp[1];
+                inClass = false;
+                continue;
+              }
             }
             hasMagic = true;
             inClass = false;
@@ -908,8 +908,8 @@ var require_minimatch = __commonJS({
       }
       var addPatternStart = false;
       switch (re.charAt(0)) {
-        case "[":
         case ".":
+        case "[":
         case "(":
           addPatternStart = true;
       }
@@ -987,7 +987,7 @@ var require_minimatch = __commonJS({
     }
     minimatch.match = function(list, pattern, options) {
       options = options || {};
-      var mm = new Minimatch(pattern, options);
+      const mm = new Minimatch(pattern, options);
       list = list.filter(function(f) {
         return mm.match(f);
       });
@@ -996,9 +996,8 @@ var require_minimatch = __commonJS({
       }
       return list;
     };
-    Minimatch.prototype.match = function match(f, partial) {
-      if (typeof partial === "undefined")
-        partial = this.partial;
+    Minimatch.prototype.match = match;
+    function match(f, partial) {
       this.debug("match", f, this.pattern);
       if (this.comment)
         return false;
@@ -1037,7 +1036,7 @@ var require_minimatch = __commonJS({
       if (options.flipNegate)
         return false;
       return this.negate;
-    };
+    }
     Minimatch.prototype.matchOne = function(file, pattern, partial) {
       var options = this.options;
       this.debug(
@@ -1088,7 +1087,11 @@ var require_minimatch = __commonJS({
         }
         var hit;
         if (typeof p === "string") {
-          hit = f === p;
+          if (options.nocase) {
+            hit = f.toLowerCase() === p.toLowerCase();
+          } else {
+            hit = f === p;
+          }
           this.debug("string match", p, f, hit);
         } else {
           hit = f.match(p);
@@ -5977,6 +5980,7 @@ function hashKey(key2) {
 }
 
 // main.ts
+var import_fs = require("fs");
 var cacheClient = createPromiseClient(
   CacheService,
   createConnectTransport({
@@ -5998,10 +6002,30 @@ cacheClient.restore(
 ).then((resp) => {
   if (resp.success) {
     console.log("Found cache entry under key: " + resp.key);
+    rememberCacheRestorationForPostStep();
   } else {
     console.log("Cache miss.");
   }
 });
+function rememberCacheRestorationForPostStep() {
+  try {
+    if ((0, import_fs.existsSync)(process.env.NX_CLOUD_ENV)) {
+      (0, import_fs.appendFileSync)(
+        process.env.NX_CLOUD_ENV,
+        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true
+`
+      );
+    } else {
+      (0, import_fs.writeFileSync)(
+        process.env.NX_CLOUD_ENV,
+        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true
+`
+      );
+    }
+  } catch (e) {
+    console.log(e);
+  }
+}
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   cacheClient


### PR DESCRIPTION
The problem here was that the env file can start out with an empty
string `""`, and the previous logic was adding a newline to that value
before adding the new environment variable, resulting in a file that
looks like this:

```
                                        # <-- empty line
NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true
```

This would not be properly parsed by the runner.

Changing the implementation to `appendFileSync`, as well as putting the newline _after_ the new variable fixes the issue