### PR TITLE
fix(install-browsers): install cypress if detected

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -11,6 +11,14 @@ launch-templates:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
+          BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
@@ -26,6 +34,14 @@ launch-templates:
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
+          BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
@@ -43,6 +59,14 @@ launch-templates:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
+          BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
@@ -58,6 +82,14 @@ launch-templates:
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
+          BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
@@ -75,6 +107,14 @@ launch-templates:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
+          BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
@@ -91,6 +131,14 @@ launch-templates:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
+          BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
@@ -106,6 +154,14 @@ launch-templates:
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
+          BASE_BRANCH: 'main'
+      - name: Restore Browser Binary Cache
+        uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/cache/main.yaml'
+        env:
+          KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
+          PATHS: |
+            '../.cache/Cypress'
+            '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v3.1/workflow-steps/install-node-modules/main.yaml'

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -11,6 +11,15 @@ if (existsSync('package.json')) {
       console.log('Installing browsers required by Playwright');
       execSync('npx playwright install', { stdio: 'inherit' });
     }
+
+    const hasCypress =
+      (json.dependencies || {}).hasOwnProperty('cypress') ||
+      (json.devDependencies || {}).hasOwnProperty('cypress');
+    if (hasCypress) {
+      console.log('Installing browsers required by Cypress');
+      execSync('npx cypress install', { stdio: 'inherit' });
+    }
+
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
- run playwright and cypress install in browser step
- cache playwright and cypress binary caches in CI

NOTE: [playwright actually recommends _not_ caching the binaries](https://playwright.dev/docs/ci#caching-browsers) as it's just faster to download anyways? and in my testing it just redownloads anyways ignoring the previous cached version, while cypress skips installing. unsure how we feel about that?

https://staging.nx.app/cipes/65ca700e7009eb25221b7ae6?step=de63fbda-0a86-4c2c-a01e-de785ba403c6&instance=job-65ca700e7009eb25221b7ae8-agent-3#step-list-pane

![WkMacM1-CHIGaWrJ_02121343](https://github.com/nrwl/nx-cloud-workflows/assets/23272162/dca39687-aa45-44f1-a57d-d21c5061f2fe)

Second note: cache paths are from the workspace root i.e. ~/workspace, but binaries are installed at ~/.cache. This means we need to path up and over to the .cache directory. 

Third note: what is the correct key here? ideally I could pass in the cypress/playwright version but can only use globs and hard coded values. for now it's the lock files + "browser" key. 


 