### PR TITLE
Include NX_STEP_GROUP_ID in CACHE_STEP_WAS_SUCCESSFUL_HIT env var

### DIFF
--- a/workflow-steps/cache/main.ts
+++ b/workflow-steps/cache/main.ts
@@ -39,16 +39,11 @@ cacheClient
 
 function rememberCacheRestorationForPostStep() {
   try {
+    const envValue = `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT_${process.env.NX_STEP_GROUP_ID}=true\n`;
     if (existsSync(process.env.NX_CLOUD_ENV)) {
-      appendFileSync(
-        process.env.NX_CLOUD_ENV,
-        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true\n`,
-      );
+      appendFileSync(process.env.NX_CLOUD_ENV, envValue);
     } else {
-      writeFileSync(
-        process.env.NX_CLOUD_ENV,
-        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true\n`,
-      );
+      writeFileSync(process.env.NX_CLOUD_ENV, envValue);
     }
   } catch (e) {
     console.log(e);

--- a/workflow-steps/cache/output/main.js
+++ b/workflow-steps/cache/output/main.js
@@ -6009,18 +6009,12 @@ cacheClient.restore(
 });
 function rememberCacheRestorationForPostStep() {
   try {
+    const envValue = `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT_${process.env.NX_STEP_GROUP_ID}=true
+`;
     if ((0, import_fs.existsSync)(process.env.NX_CLOUD_ENV)) {
-      (0, import_fs.appendFileSync)(
-        process.env.NX_CLOUD_ENV,
-        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true
-`
-      );
+      (0, import_fs.appendFileSync)(process.env.NX_CLOUD_ENV, envValue);
     } else {
-      (0, import_fs.writeFileSync)(
-        process.env.NX_CLOUD_ENV,
-        `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT=true
-`
-      );
+      (0, import_fs.writeFileSync)(process.env.NX_CLOUD_ENV, envValue);
     }
   } catch (e) {
     console.log(e);

--- a/workflow-steps/cache/output/post.js
+++ b/workflow-steps/cache/output/post.js
@@ -5968,7 +5968,8 @@ function hashKey(key) {
 }
 
 // post.ts
-if (!!process.env.NX_CACHE_STEP_WAS_SUCCESSFUL_HIT) {
+var cacheWasHit = process.env[`NX_CACHE_STEP_WAS_SUCCESSFUL_HIT_${process.env.NX_STEP_GROUP_ID}`] === "true";
+if (!!cacheWasHit) {
   console.log("Skipped storing to cache");
 } else {
   const cacheClient = createPromiseClient(

--- a/workflow-steps/cache/post.ts
+++ b/workflow-steps/cache/post.ts
@@ -4,7 +4,11 @@ import { CacheService } from './generated_protos/cache_connect';
 import { StoreRequest, StoreResponse } from './generated_protos/cache_pb';
 import { hashKey } from './hashing-utils';
 
-if (!!process.env.NX_CACHE_STEP_WAS_SUCCESSFUL_HIT) {
+const cacheWasHit =
+  process.env[
+    `NX_CACHE_STEP_WAS_SUCCESSFUL_HIT_${process.env.NX_STEP_GROUP_ID}`
+  ] === 'true';
+if (!!cacheWasHit) {
   console.log('Skipped storing to cache');
 } else {
   const cacheClient = createPromiseClient(


### PR DESCRIPTION
There was an edge case where if multiple caching steps were used and only one was hit, one cache hit would cause both cache store processes to skip when it should only stop the one it pertains to.

This change adds the STEP_ID environment variable at the end of the environment variable, which should no fix the issue