### PR TITLE
checkout sha instead of PR specifics

### DIFF
--- a/workflow-steps/cache/output/main.js
+++ b/workflow-steps/cache/output/main.js
@@ -530,12 +530,12 @@ var require_minimatch = __commonJS({
   "../../node_modules/minimatch/minimatch.js"(exports, module2) {
     module2.exports = minimatch;
     minimatch.Minimatch = Minimatch;
-    var path = (() => {
+    var path = function() {
       try {
         return require("path");
       } catch (e) {
       }
-    })() || {
+    }() || {
       sep: "/"
     };
     minimatch.sep = path.sep;
@@ -568,9 +568,8 @@ var require_minimatch = __commonJS({
       };
     }
     function ext(a, b) {
-      a = a || {};
       b = b || {};
-      const t = {};
+      var t = {};
       Object.keys(a).forEach(function(k) {
         t[k] = a[k];
       });
@@ -583,14 +582,14 @@ var require_minimatch = __commonJS({
       if (!def || typeof def !== "object" || !Object.keys(def).length) {
         return minimatch;
       }
-      const orig = minimatch;
-      const m = function minimatch2(p, pattern, options) {
+      var orig = minimatch;
+      var m = function minimatch2(p, pattern, options) {
         return orig(p, pattern, ext(def, options));
       };
       m.Minimatch = function Minimatch2(pattern, options) {
         return new orig.Minimatch(pattern, ext(def, options));
       };
-      m.Minimatch.defaults = (options) => {
+      m.Minimatch.defaults = function defaults(options) {
         return orig.defaults(ext(def, options)).Minimatch;
       };
       m.filter = function filter2(pattern, options) {
@@ -620,8 +619,6 @@ var require_minimatch = __commonJS({
       if (!options.nocomment && pattern.charAt(0) === "#") {
         return false;
       }
-      if (pattern.trim() === "")
-        return p === "";
       return new Minimatch(pattern, options).match(p);
     }
     function Minimatch(pattern, options) {
@@ -632,7 +629,7 @@ var require_minimatch = __commonJS({
       if (!options)
         options = {};
       pattern = pattern.trim();
-      if (path.sep !== "/") {
+      if (!options.allowWindowsEscape && path.sep !== "/") {
         pattern = pattern.split(path.sep).join("/");
       }
       this.options = options;
@@ -642,14 +639,13 @@ var require_minimatch = __commonJS({
       this.negate = false;
       this.comment = false;
       this.empty = false;
+      this.partial = !!options.partial;
       this.make();
     }
     Minimatch.prototype.debug = function() {
     };
     Minimatch.prototype.make = make;
     function make() {
-      if (this._made)
-        return;
       var pattern = this.pattern;
       var options = this.options;
       if (!options.nocomment && pattern.charAt(0) === "#") {
@@ -663,7 +659,9 @@ var require_minimatch = __commonJS({
       this.parseNegate();
       var set = this.globSet = this.braceExpand();
       if (options.debug)
-        this.debug = console.error;
+        this.debug = function debug() {
+          console.error.apply(console, arguments);
+        };
       this.debug(this.pattern, set);
       set = this.globParts = set.map(function(s) {
         return s.split(slashSplit);
@@ -715,7 +713,7 @@ var require_minimatch = __commonJS({
       return expand(pattern);
     }
     var MAX_PATTERN_LENGTH = 1024 * 64;
-    var assertValidPattern = (pattern) => {
+    var assertValidPattern = function(pattern) {
       if (typeof pattern !== "string") {
         throw new TypeError("invalid pattern");
       }
@@ -728,12 +726,16 @@ var require_minimatch = __commonJS({
     function parse(pattern, isSub) {
       assertValidPattern(pattern);
       var options = this.options;
-      if (!options.noglobstar && pattern === "**")
-        return GLOBSTAR;
+      if (pattern === "**") {
+        if (!options.noglobstar)
+          return GLOBSTAR;
+        else
+          pattern = "*";
+      }
       if (pattern === "")
         return "";
       var re = "";
-      var hasMagic = false;
+      var hasMagic = !!options.nocase;
       var escaping = false;
       var patternListStack = [];
       var negativeLists = [];
@@ -856,17 +858,15 @@ var require_minimatch = __commonJS({
               escaping = false;
               continue;
             }
-            if (inClass) {
-              var cs = pattern.substring(classStart + 1, i);
-              try {
-                RegExp("[" + cs + "]");
-              } catch (er) {
-                var sp = this.parse(cs, SUBPARSE);
-                re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
-                hasMagic = hasMagic || sp[1];
-                inClass = false;
-                continue;
-              }
+            var cs = pattern.substring(classStart + 1, i);
+            try {
+              RegExp("[" + cs + "]");
+            } catch (er) {
+              var sp = this.parse(cs, SUBPARSE);
+              re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
+              hasMagic = hasMagic || sp[1];
+              inClass = false;
+              continue;
             }
             hasMagic = true;
             inClass = false;
@@ -908,8 +908,8 @@ var require_minimatch = __commonJS({
       }
       var addPatternStart = false;
       switch (re.charAt(0)) {
-        case ".":
         case "[":
+        case ".":
         case "(":
           addPatternStart = true;
       }
@@ -987,7 +987,7 @@ var require_minimatch = __commonJS({
     }
     minimatch.match = function(list, pattern, options) {
       options = options || {};
-      const mm = new Minimatch(pattern, options);
+      var mm = new Minimatch(pattern, options);
       list = list.filter(function(f) {
         return mm.match(f);
       });
@@ -996,8 +996,9 @@ var require_minimatch = __commonJS({
       }
       return list;
     };
-    Minimatch.prototype.match = match;
-    function match(f, partial) {
+    Minimatch.prototype.match = function match(f, partial) {
+      if (typeof partial === "undefined")
+        partial = this.partial;
       this.debug("match", f, this.pattern);
       if (this.comment)
         return false;
@@ -1036,7 +1037,7 @@ var require_minimatch = __commonJS({
       if (options.flipNegate)
         return false;
       return this.negate;
-    }
+    };
     Minimatch.prototype.matchOne = function(file, pattern, partial) {
       var options = this.options;
       this.debug(
@@ -1087,11 +1088,7 @@ var require_minimatch = __commonJS({
         }
         var hit;
         if (typeof p === "string") {
-          if (options.nocase) {
-            hit = f.toLowerCase() === p.toLowerCase();
-          } else {
-            hit = f === p;
-          }
+          hit = f === p;
           this.debug("string match", p, f, hit);
         } else {
           hit = f.match(p);

--- a/workflow-steps/cache/output/post.js
+++ b/workflow-steps/cache/output/post.js
@@ -525,12 +525,12 @@ var require_minimatch = __commonJS({
   "../../node_modules/minimatch/minimatch.js"(exports, module2) {
     module2.exports = minimatch;
     minimatch.Minimatch = Minimatch;
-    var path = (() => {
+    var path = function() {
       try {
         return require("path");
       } catch (e) {
       }
-    })() || {
+    }() || {
       sep: "/"
     };
     minimatch.sep = path.sep;
@@ -563,9 +563,8 @@ var require_minimatch = __commonJS({
       };
     }
     function ext(a, b) {
-      a = a || {};
       b = b || {};
-      const t = {};
+      var t = {};
       Object.keys(a).forEach(function(k) {
         t[k] = a[k];
       });
@@ -578,14 +577,14 @@ var require_minimatch = __commonJS({
       if (!def || typeof def !== "object" || !Object.keys(def).length) {
         return minimatch;
       }
-      const orig = minimatch;
-      const m = function minimatch2(p, pattern, options) {
+      var orig = minimatch;
+      var m = function minimatch2(p, pattern, options) {
         return orig(p, pattern, ext(def, options));
       };
       m.Minimatch = function Minimatch2(pattern, options) {
         return new orig.Minimatch(pattern, ext(def, options));
       };
-      m.Minimatch.defaults = (options) => {
+      m.Minimatch.defaults = function defaults(options) {
         return orig.defaults(ext(def, options)).Minimatch;
       };
       m.filter = function filter2(pattern, options) {
@@ -615,8 +614,6 @@ var require_minimatch = __commonJS({
       if (!options.nocomment && pattern.charAt(0) === "#") {
         return false;
       }
-      if (pattern.trim() === "")
-        return p === "";
       return new Minimatch(pattern, options).match(p);
     }
     function Minimatch(pattern, options) {
@@ -627,7 +624,7 @@ var require_minimatch = __commonJS({
       if (!options)
         options = {};
       pattern = pattern.trim();
-      if (path.sep !== "/") {
+      if (!options.allowWindowsEscape && path.sep !== "/") {
         pattern = pattern.split(path.sep).join("/");
       }
       this.options = options;
@@ -637,14 +634,13 @@ var require_minimatch = __commonJS({
       this.negate = false;
       this.comment = false;
       this.empty = false;
+      this.partial = !!options.partial;
       this.make();
     }
     Minimatch.prototype.debug = function() {
     };
     Minimatch.prototype.make = make;
     function make() {
-      if (this._made)
-        return;
       var pattern = this.pattern;
       var options = this.options;
       if (!options.nocomment && pattern.charAt(0) === "#") {
@@ -658,7 +654,9 @@ var require_minimatch = __commonJS({
       this.parseNegate();
       var set = this.globSet = this.braceExpand();
       if (options.debug)
-        this.debug = console.error;
+        this.debug = function debug() {
+          console.error.apply(console, arguments);
+        };
       this.debug(this.pattern, set);
       set = this.globParts = set.map(function(s) {
         return s.split(slashSplit);
@@ -710,7 +708,7 @@ var require_minimatch = __commonJS({
       return expand(pattern);
     }
     var MAX_PATTERN_LENGTH = 1024 * 64;
-    var assertValidPattern = (pattern) => {
+    var assertValidPattern = function(pattern) {
       if (typeof pattern !== "string") {
         throw new TypeError("invalid pattern");
       }
@@ -723,12 +721,16 @@ var require_minimatch = __commonJS({
     function parse(pattern, isSub) {
       assertValidPattern(pattern);
       var options = this.options;
-      if (!options.noglobstar && pattern === "**")
-        return GLOBSTAR;
+      if (pattern === "**") {
+        if (!options.noglobstar)
+          return GLOBSTAR;
+        else
+          pattern = "*";
+      }
       if (pattern === "")
         return "";
       var re = "";
-      var hasMagic = false;
+      var hasMagic = !!options.nocase;
       var escaping = false;
       var patternListStack = [];
       var negativeLists = [];
@@ -851,17 +853,15 @@ var require_minimatch = __commonJS({
               escaping = false;
               continue;
             }
-            if (inClass) {
-              var cs = pattern.substring(classStart + 1, i);
-              try {
-                RegExp("[" + cs + "]");
-              } catch (er) {
-                var sp = this.parse(cs, SUBPARSE);
-                re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
-                hasMagic = hasMagic || sp[1];
-                inClass = false;
-                continue;
-              }
+            var cs = pattern.substring(classStart + 1, i);
+            try {
+              RegExp("[" + cs + "]");
+            } catch (er) {
+              var sp = this.parse(cs, SUBPARSE);
+              re = re.substr(0, reClassStart) + "\\[" + sp[0] + "\\]";
+              hasMagic = hasMagic || sp[1];
+              inClass = false;
+              continue;
             }
             hasMagic = true;
             inClass = false;
@@ -903,8 +903,8 @@ var require_minimatch = __commonJS({
       }
       var addPatternStart = false;
       switch (re.charAt(0)) {
-        case ".":
         case "[":
+        case ".":
         case "(":
           addPatternStart = true;
       }
@@ -982,7 +982,7 @@ var require_minimatch = __commonJS({
     }
     minimatch.match = function(list, pattern, options) {
       options = options || {};
-      const mm = new Minimatch(pattern, options);
+      var mm = new Minimatch(pattern, options);
       list = list.filter(function(f) {
         return mm.match(f);
       });
@@ -991,8 +991,9 @@ var require_minimatch = __commonJS({
       }
       return list;
     };
-    Minimatch.prototype.match = match;
-    function match(f, partial) {
+    Minimatch.prototype.match = function match(f, partial) {
+      if (typeof partial === "undefined")
+        partial = this.partial;
       this.debug("match", f, this.pattern);
       if (this.comment)
         return false;
@@ -1031,7 +1032,7 @@ var require_minimatch = __commonJS({
       if (options.flipNegate)
         return false;
       return this.negate;
-    }
+    };
     Minimatch.prototype.matchOne = function(file, pattern, partial) {
       var options = this.options;
       this.debug(
@@ -1082,11 +1083,7 @@ var require_minimatch = __commonJS({
         }
         var hit;
         if (typeof p === "string") {
-          if (options.nocase) {
-            hit = f.toLowerCase() === p.toLowerCase();
-          } else {
-            hit = f === p;
-          }
+          hit = f === p;
           this.debug("string match", p, f, hit);
         } else {
           hit = f.match(p);

--- a/workflow-steps/checkout/main.ts
+++ b/workflow-steps/checkout/main.ts
@@ -6,11 +6,10 @@ const nxBranch = process.env.NX_BRANCH; // This can be a PR number or a branch n
 const depth = process.env.GIT_CHECKOUT_DEPTH || 1;
 const fetchTags = process.env.GIT_FETCH_TAGS === 'true';
 
-// TODO: infer this in cases where the NX_BRANCH is a branch name despite being a PR (certain CI providers, not GitHub)
-const isPR = !isNaN(parseInt(nxBranch!));
-
 if (process.platform != 'win32') {
-  execSync(`git config --global --add safe.directory /home/workflows/workspace`);
+  execSync(
+    `git config --global --add safe.directory /home/workflows/workspace`,
+  );
 }
 execSync('git init .');
 execSync(`git remote add origin ${repoUrl}`);
@@ -20,23 +19,13 @@ if (depth === '0') {
   execSync(
     'git fetch --prune --progress --no-recurse-submodules --tags origin "+refs/heads/*:refs/remotes/origin/*"',
   );
-  if (isPR) {
-    // Fetch PR specific references for GitHub
-    execSync(
-      `git fetch origin pull/${nxBranch}/head:refs/remotes/origin/pr/${nxBranch}`,
-    );
-  }
-  // Checkout using the appropriate reference
-  const checkoutRef = isPR ? 'refs/remotes/origin/pr/' + nxBranch : commitSha;
-  execSync(`git checkout --progress --force ${checkoutRef}`);
 } else {
   // Fetch with specified depth
-  const fetchRef = isPR ? `pull/${nxBranch}/head` : `${nxBranch}`;
   const tagsArg = fetchTags ? ' --tags' : '--no-tags';
   execSync(
-    `git fetch ${tagsArg} --prune --progress --no-recurse-submodules --depth=${depth} origin ${fetchRef}`,
+    `git fetch ${tagsArg} --prune --progress --no-recurse-submodules --depth=${depth} origin ${commitSha}`,
   );
-  // Checkout the branch or PR
-  const checkoutRef = isPR ? 'FETCH_HEAD' : `origin/${nxBranch}`;
-  execSync(`git checkout --progress --force -B ${nxBranch} ${checkoutRef}`);
 }
+
+// Checkout the branch or PR
+execSync(`git checkout --progress --force -B ${nxBranch} ${commitSha}`);

--- a/workflow-steps/checkout/output/main.js
+++ b/workflow-steps/checkout/output/main.js
@@ -5,9 +5,10 @@ var commitSha = process.env.NX_COMMIT_SHA;
 var nxBranch = process.env.NX_BRANCH;
 var depth = process.env.GIT_CHECKOUT_DEPTH || 1;
 var fetchTags = process.env.GIT_FETCH_TAGS === "true";
-var isPR = !isNaN(parseInt(nxBranch));
 if (process.platform != "win32") {
-  (0, import_child_process.execSync)(`git config --global --add safe.directory /home/workflows/workspace`);
+  (0, import_child_process.execSync)(
+    `git config --global --add safe.directory /home/workflows/workspace`
+  );
 }
 (0, import_child_process.execSync)("git init .");
 (0, import_child_process.execSync)(`git remote add origin ${repoUrl}`);
@@ -15,19 +16,10 @@ if (depth === "0") {
   (0, import_child_process.execSync)(
     'git fetch --prune --progress --no-recurse-submodules --tags origin "+refs/heads/*:refs/remotes/origin/*"'
   );
-  if (isPR) {
-    (0, import_child_process.execSync)(
-      `git fetch origin pull/${nxBranch}/head:refs/remotes/origin/pr/${nxBranch}`
-    );
-  }
-  const checkoutRef = isPR ? "refs/remotes/origin/pr/" + nxBranch : commitSha;
-  (0, import_child_process.execSync)(`git checkout --progress --force ${checkoutRef}`);
 } else {
-  const fetchRef = isPR ? `pull/${nxBranch}/head` : `${nxBranch}`;
   const tagsArg = fetchTags ? " --tags" : "--no-tags";
   (0, import_child_process.execSync)(
-    `git fetch ${tagsArg} --prune --progress --no-recurse-submodules --depth=${depth} origin ${fetchRef}`
+    `git fetch ${tagsArg} --prune --progress --no-recurse-submodules --depth=${depth} origin ${commitSha}`
   );
-  const checkoutRef = isPR ? "FETCH_HEAD" : `origin/${nxBranch}`;
-  (0, import_child_process.execSync)(`git checkout --progress --force -B ${nxBranch} ${checkoutRef}`);
 }
+(0, import_child_process.execSync)(`git checkout --progress --force -B ${nxBranch} ${commitSha}`);


### PR DESCRIPTION
## Current behaviour
When trying to use workflows in VSC environments that were not github, the checkout would fail because of github "PR" specifics. For example, gitlab would use "MR". 
## Expected behaviour
Checkouts now use only the NX_COMMIT_SHA which does not use any github PR specifics. This also simplifies the checkout code so that we don't have to check if we're pulling code from a main branch or a PR branch. 