### PR TITLE
chore: update launch templates to use latest version of steps

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -1,18 +1,18 @@
 launch-templates:
   linux-small-js:
-    resource-class: "docker_linux_amd64/small"
+    resource-class: 'docker_linux_amd64/small'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -20,23 +20,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-js:
-    resource-class: "docker_linux_amd64/medium"
+    resource-class: 'docker_linux_amd64/medium'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -44,23 +44,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-plus-js:
-    resource-class: "docker_linux_amd64/medium+"
+    resource-class: 'docker_linux_amd64/medium+'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -68,23 +68,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-js:
-    resource-class: "docker_linux_amd64/large"
+    resource-class: 'docker_linux_amd64/large'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -92,23 +92,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-plus-js:
-    resource-class: "docker_linux_amd64/large+"
+    resource-class: 'docker_linux_amd64/large+'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -116,23 +116,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-js:
-    resource-class: "docker_linux_amd64/extra_large"
+    resource-class: 'docker_linux_amd64/extra_large'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -140,23 +140,23 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-plus-js:
-    resource-class: "docker_linux_amd64/extra_large+"
+    resource-class: 'docker_linux_amd64/extra_large+'
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
           PATHS: 'node_modules'
           BASE_BRANCH: 'main'
       - name: Restore Browser Binary Cache
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:
           KEY: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           PATHS: |
@@ -164,6 +164,6 @@ launch-templates:
             '../.cache/ms-playwright'
           BASE_BRANCH: 'main'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-node-modules/main.yaml'
       - name: Install Browsers (if needed)
-        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/install-browsers/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'


### PR DESCRIPTION
Bumps version from v3.5 to v3.6