### PR TITLE
chore: only use 3.5 for checkout step in `bump-version-in-template` PR

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -4,7 +4,7 @@ launch-templates:
     image: 'ubuntu22.04-node20.11-v3'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v3.5/workflow-steps/checkout/main.yaml'
       - name: Restore Node Modules Cache
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/cache/main.yaml'
         env:


### PR DESCRIPTION
I don't have write access, so I have to PR a PR to push these changes rares asked for.
- chore: reported issues with v3.6 for checkout step, using 3.5 for now
