### PR TITLE
feat(launch-templates): bump image to ubuntu22.04-node20.11-v7

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -1,7 +1,7 @@
 launch-templates:
   linux-small-js:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -25,7 +25,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -49,7 +49,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-plus-js:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -73,7 +73,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-js:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -97,7 +97,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-plus-js:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -121,7 +121,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-js:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -145,7 +145,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-plus-js:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -169,7 +169,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-small-jvm:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -179,7 +179,7 @@ launch-templates:
         script: ./nx --version
   linux-medium-jvm:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -189,7 +189,7 @@ launch-templates:
         script: ./nx --version
   linux-medium-plus-jvm:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -199,7 +199,7 @@ launch-templates:
         script: ./nx --version
   linux-large-jvm:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -209,7 +209,7 @@ launch-templates:
         script: ./nx --version
   linux-large-plus-jvm:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -219,7 +219,7 @@ launch-templates:
         script: ./nx --version
   linux-extra-large-jvm:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -229,7 +229,7 @@ launch-templates:
         script: ./nx --version
   linux-extra-large-plus-jvm:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.11-v6'
+    image: 'ubuntu22.04-node20.11-v7'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'

--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -1,7 +1,7 @@
 launch-templates:
   linux-small-js:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -25,7 +25,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -49,7 +49,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-medium-plus-js:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -73,7 +73,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-js:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -97,7 +97,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-large-plus-js:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -121,7 +121,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-js:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -145,7 +145,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-extra-large-plus-js:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -169,7 +169,7 @@ launch-templates:
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/install-browsers/main.yaml'
   linux-small-jvm:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -179,7 +179,7 @@ launch-templates:
         script: ./nx --version
   linux-medium-jvm:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -189,7 +189,7 @@ launch-templates:
         script: ./nx --version
   linux-medium-plus-jvm:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -199,7 +199,7 @@ launch-templates:
         script: ./nx --version
   linux-large-jvm:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -209,7 +209,7 @@ launch-templates:
         script: ./nx --version
   linux-large-plus-jvm:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -219,7 +219,7 @@ launch-templates:
         script: ./nx --version
   linux-extra-large-jvm:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'
@@ -229,7 +229,7 @@ launch-templates:
         script: ./nx --version
   linux-extra-large-plus-jvm:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.11-v5'
+    image: 'ubuntu22.04-node20.11-v6'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v3.6/workflow-steps/checkout/main.yaml'


### PR DESCRIPTION
ubuntu22.04-node20.11-v7 has corepack enabled by default and java version bumps, this will
unblock people relying on corepack (like yarn v4 users) to have their
correct package manager version installed automatically (yarn/pnpm)

this image was also created right when pnpm v9 was released which has
some lockfile issues with Nx, so this image contains pnpm v8 similar to
the previous v5 image. If people want to use v9, they can do so via
corepack packageManager field in the package.json
https://nodejs.org/api/packages.html#packagemanager

Example workspace using yarn v4 https://github.com/barbados-clemens/yarn-workspace

With CIPE using correct package manager with corepack: https://staging.nx.app/cipes/6633b88d2e3c7202bb72d5bc?step=32fbd017-70d7-4e91-aa77-876e184974e5&instance=job-6633b88d2e3c7202bb72d5bd-agent-2#step-list-pane