### PR TITLE
feat(install-node-modules): allow controlling legacy-peer-deps for npm

### DIFF
--- a/workflow-steps/install-node-modules/README.md
+++ b/workflow-steps/install-node-modules/README.md
@@ -1,0 +1,18 @@
+```yaml
+- name: Install Node Nodules
+  uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
+  inputs:
+    npm_legacy_install: 'true'
+```
+
+### Options
+
+#### npm_legacy_install
+
+This input is optional and defaults to `true` if not specified.
+
+If set to `true`, the step will install the node modules using `npm ci --legacy-peer-deps` when the npm package manager is used.
+
+If set to `false`, the step will install the node modules using `npm ci` when the npm package manager is used.
+
+If you do not already have a [custom launch template](https://nx.dev/ci/reference/launch-templates), you can also control this behavior by setting the `NX_CLOUD_NPM_LEGACY_INSTALL` environment variable to `true` or `false` in your main agent and [pass the variable via `--with-env-vars="NX_CLOUD_NPM_LEGACY_INSTALL"`](https://nx.dev/ci/reference/launch-templates#pass-environment-variables-to-agents)

--- a/workflow-steps/install-node-modules/main.js
+++ b/workflow-steps/install-node-modules/main.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
 
 const command = getInstallCommand();
+
 if (command) {
   console.log(`Installing dependencies using ${command.split(' ')[0]}`);
   console.log(`  Running command: ${command}\n`);
@@ -15,7 +16,22 @@ if (command) {
 
 function getInstallCommand() {
   if (existsSync('package-lock.json')) {
-    return 'npm ci --legacy-peer-deps';
+    const legacyInstallInput =
+      process.env.NX_CLOUD_INPUT_npm_legacy_install ||
+      // allow controlling via env var form main agent so people don't need to make a custom launch template just for 1 input
+      process.env.NX_CLOUD_NPM_LEGACY_INSTALL;
+
+    if (
+      legacyInstallInput !== undefined &&
+      (legacyInstallInput === 'false' || legacyInstallInput === false)
+    ) {
+      return 'npm ci';
+    } else {
+      console.log(
+        "Installing with --legacy-peer-deps for compatiblity, set the npm_legacy_install step input or NX_CLOUD_NPM_LEGACY_INSTALL env var to 'false' to disable.",
+      );
+      return 'npm ci --legacy-peer-deps';
+    }
   } else if (existsSync('yarn.lock')) {
     const [major] = execSync(`yarn --version`, {
       encoding: 'utf-8',

--- a/workflow-steps/install-node-modules/main.yaml
+++ b/workflow-steps/install-node-modules/main.yaml
@@ -1,6 +1,10 @@
 name: Install Node Modules
 description: Installs node_modules using your configured package manager.
 
+inputs:
+  - name: npm_legacy_install
+    description: 'Install with legacy peer dependency resolution. This only applies to npm.'
+
 definition:
   using: 'node'
   main: workflow-steps/install-node-modules/main.js


### PR DESCRIPTION
Most people should not being using legacy peer deps anymore, but we
understand the compat needs and could be a breaking change to just
change this from under people.

This PR introduces a new input to the install-node-modules step to
enable/disable the usage of `--legacy-peer-deps` arg for `npm ci`
install command.

Since it's a lot of overhead to ask people to create a launch template
just to control 1 input, this also introduces the
`NX_CLOUD_NPM_LEGACY_INSTALL` env var that can be sent via the main
agent to controll this behavior as well.
