### PR TITLE
feat(install-node-modules): retry package manager installs

### DIFF
--- a/workflow-steps/install-node-modules/main.js
+++ b/workflow-steps/install-node-modules/main.js
@@ -1,17 +1,59 @@
 const { execSync } = require('child_process');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
 
-const command = getInstallCommand();
+async function main() {
+  const command = getInstallCommand();
 
-if (command) {
-  console.log(`Installing dependencies using ${command.split(' ')[0]}`);
-  console.log(`  Running command: ${command}\n`);
-  execSync(command, { stdio: 'inherit' });
-  patchJest();
-} else {
-  throw new Error(
-    'Could not find lock file. Please ensure you have a lock file before running this command.',
-  );
+  if (command) {
+    console.log(`Installing dependencies using ${command.split(' ')[0]}`);
+    console.log(`  Running command: ${command}\n`);
+
+    const maxRetries = Number(process.env.NX_CLOUD_INPUT_max_retries) || 3;
+    await runCommandWithRetries(command, maxRetries);
+  } else {
+    throw new Error(
+      'Could not find lock file. Please ensure you have a lock file before running this command.',
+    );
+  }
+}
+
+/**
+ * Retry the command up to maxRetries times
+ * @param {string} command
+ * @param {number} maxRetries
+ */
+async function runCommandWithRetries(command, maxRetries) {
+  let retryCount = 0;
+
+  while (retryCount < maxRetries) {
+    try {
+      execSync(command);
+      patchJest();
+      console.log('Installed dependencies successfully!');
+      break;
+    } catch (e) {
+      retryCount++;
+
+      if (retryCount >= maxRetries) {
+        throw new Error(`Failed to install node_modules via ${command}`);
+      }
+
+      const delay = Math.max(
+        3_000,
+        Math.pow(2, retryCount) * Math.random() * 1_250,
+      );
+      console.log(
+        `Installing node_modules failed. Retrying install in ${(
+          delay / 1000
+        ).toFixed(0)} seconds...`,
+      );
+      if (process.env.NX_VERBOSE_LOGGING === 'true') {
+        console.warn(e);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
 }
 
 function getInstallCommand() {
@@ -69,3 +111,5 @@ function patchJest() {
     console.log('no need to patch jest');
   }
 }
+
+main();


### PR DESCRIPTION
retry package manager install of node_modules. 
NPM and PNPM support configuration via .npmrc for the `fetch-retries` (default 2). but yarn doesn't have a config option. only options to configure the retry timeout for network requests. 

To make it simpler I've opted to just re-run the command in attempt to retry with a delay (min of 3 seconds).