### PR TITLE
fix(launch-template): remove playwright from browser cache

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -17,7 +17,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -41,7 +40,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -65,7 +63,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -89,7 +86,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -113,7 +109,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -137,7 +132,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
@@ -161,7 +155,6 @@ launch-templates:
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
           paths: |
             '../.cache/Cypress'
-            '../.cache/ms-playwright'
           base-branch: 'main'
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'


### PR DESCRIPTION
Playwright recommends not caching the binaries since restoring from the
cache usually takes longer than just downloading from the CDN.

> Caching browser binaries is not recommended, since the amount of time
it takes to restore the cache is comparable to the time it takes to
download the binaries. Especially under Linux, operating system
dependencies need to be installed, which are not cacheable.

https://playwright.dev/docs/ci#caching-browsers
