### PR TITLE
feat(install-browsers): automatically detect out of sync playwright deps and attempt to install

### DIFF
--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -1,61 +1,95 @@
-const { execSync } = require('child_process');
+//@ts-check
+const { execSync, exec } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 
-if (existsSync('package.json')) {
-  try {
-    const json = JSON.parse(readFileSync('package.json').toString());
-    const hasPlaywright =
-      (json.dependencies || {}).hasOwnProperty('@playwright/test') ||
-      (json.devDependencies || {}).hasOwnProperty('@playwright/test');
-    if (hasPlaywright) {
-      console.log('Installing browsers required by Playwright');
-      const output = execSync('npx playwright install', {
-        stdio: 'inherit',
-      }).toString();
+main();
 
-      if (output.includes('missing dependencies')) {
+async function main() {
+  if (!existsSync('package.json')) {
+    console.log(
+      'Unable to determine which e2e test runner being used. Missing root level package.json file',
+    );
+    return;
+  }
+
+  const json = JSON.parse(readFileSync('package.json').toString());
+  const hasPlaywright =
+    (json.dependencies || {}).hasOwnProperty('@playwright/test') ||
+    (json.devDependencies || {}).hasOwnProperty('@playwright/test');
+
+  const hasCypress =
+    (json.dependencies || {}).hasOwnProperty('cypress') ||
+    (json.devDependencies || {}).hasOwnProperty('cypress');
+
+  if (hasPlaywright) {
+    console.log('Installing browsers required by Playwright');
+    try {
+      const output = await runCmdAsync('npx playwright install');
+
+      if (output.stderr.includes('apt-get install')) {
         console.log(
-          'Playwright detected missing dependencies. Attempting to install...',
+          '\nDetected missing Playwright dependencies. Attempting manual install...',
         );
-        try {
-          // playwright has detected out of sync dependencies on the host machine, we we'll try to manually install them to prevent hard to debug failures
-          const installDryRun = execSync(
-            'npx playwright install --with-deps --dry-run',
-            { stdio: 'pipe' },
-          ).toString();
-
-          const [installCommand] = installDryRun.match(
-            /apt-get install .+(?=")/gi,
-          );
-          if (installCommand) {
-            console.log(
-              `Installing Playwright dependencies:\n${installCommand}`,
-            );
-            execSync(installCommand, { stdio: 'inherit' });
-          }
-        } catch (installError) {
-          console.error(
-            'There was an issue installing dependencies for Playwright.',
-          );
-          console.error(installError);
-          console.log(
-            'You can create a custom launch template and add a step to manually install the missing Playwright dependencies in order to get around this error.',
-          );
-          console.log(
-            'See docs here: https://nx.dev/ci/reference/launch-templates',
-          );
+        // playwright has detected out of sync dependencies on the host machine, we we'll try to manually install them to prevent hard to debug failures
+        const [installCommand] =
+          output.stderr.match(/apt-get install (\b\w+\b )+/gi) || [];
+        if (installCommand) {
+          installDeps(`sudo ${installCommand.trim()} -y`);
+        } else {
+          console.warn('Unable to parse install command');
         }
       }
+    } catch (e) {
+      console.error(e);
+      console.log('There is an issue install playwright dependencies');
     }
+  }
 
-    const hasCypress =
-      (json.dependencies || {}).hasOwnProperty('cypress') ||
-      (json.devDependencies || {}).hasOwnProperty('cypress');
-    if (hasCypress) {
-      console.log('Installing browsers required by Cypress');
-      execSync('npx cypress install', { stdio: 'inherit' });
-    }
-  } catch (e) {
-    console.error(e);
+  if (hasCypress) {
+    console.log('Installing browsers required by Cypress');
+    execSync('npx cypress install', { stdio: 'inherit' });
+  }
+  console.log('Done');
+}
+
+/**
+ * @param {string} cmd
+ * @returns {Promise<{ stdout: string; stderr: string; code: number | null; }>}
+ */
+async function runCmdAsync(cmd) {
+  return new Promise((res) => {
+    let stdout = '';
+    let stderr = '';
+    const proc = exec(cmd);
+
+    proc?.stdout?.on('data', (data) => {
+      stdout += data.toString();
+      process.stdout.write(data);
+    });
+
+    proc?.stderr?.on('data', (data) => {
+      stderr += data.toString();
+      process.stderr.write(data);
+    });
+
+    proc.on('close', (code) => {
+      res({ stdout, stderr, code });
+    });
+  });
+}
+
+/**
+ * @param {string} installCommand
+ */
+function installDeps(installCommand) {
+  try {
+    console.log(`Running "${installCommand}"`);
+    execSync(installCommand.trim(), { stdio: 'inherit' });
+  } catch (installError) {
+    console.error('There was an issue installing dependencies for Playwright.');
+    console.log(
+      'You can create a custom launch template and add a step to manually install the missing Playwright dependencies in order to get around this error.',
+    );
+    console.log('See docs here: https://nx.dev/ci/reference/launch-templates');
   }
 }

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -9,7 +9,43 @@ if (existsSync('package.json')) {
       (json.devDependencies || {}).hasOwnProperty('@playwright/test');
     if (hasPlaywright) {
       console.log('Installing browsers required by Playwright');
-      execSync('npx playwright install', { stdio: 'inherit' });
+      const output = execSync('npx playwright install', {
+        stdio: 'inherit',
+      }).toString();
+
+      if (output.includes('missing dependencies')) {
+        console.log(
+          'Playwright detected missing dependencies. Attempting to install...',
+        );
+        try {
+          // playwright has detected out of sync dependencies on the host machine, we we'll try to manually install them to prevent hard to debug failures
+          const installDryRun = execSync(
+            'npx playwright install --with-deps --dry-run',
+            { stdio: 'pipe' },
+          ).toString();
+
+          const [installCommand] = installDryRun.match(
+            /apt-get install .+(?=")/gi,
+          );
+          if (installCommand) {
+            console.log(
+              `Installing Playwright dependencies:\n${installCommand}`,
+            );
+            execSync(installCommand, { stdio: 'inherit' });
+          }
+        } catch (installError) {
+          console.error(
+            'There was an issue installing dependencies for Playwright.',
+          );
+          console.error(installError);
+          console.log(
+            'You can create a custom launch template and add a step to manually install the missing Playwright dependencies in order to get around this error.',
+          );
+          console.log(
+            'See docs here: https://nx.dev/ci/reference/launch-templates',
+          );
+        }
+      }
     }
 
     const hasCypress =
@@ -19,7 +55,6 @@ if (existsSync('package.json')) {
       console.log('Installing browsers required by Cypress');
       execSync('npx cypress install', { stdio: 'inherit' });
     }
-
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
Sometimes when playwright releases a new version the system deps
required also change. This change attempts to catch the out of sync deps
from a playwright warning, and then install the deps playwright needs to
prevent hard to debug issues with playwright not working.



working here: https://staging.nx.app/cipes/6781992b5c0e286a78bb1165?step=f133e59a-7e48-4267-854d-3390779377d6&instance=job-6781992b5c0e286a78bb1166-0-agent-0&launchTemplate=custom-linux-medium-js#step-list-pane

example output: 
```
 Playwright Host validation warning: 
69   ╔══════════════════════════════════════════════════════╗
70   ║ Host system is missing dependencies to run browsers. ║
71   ║ Please install them with the following command:      ║
72   ║                                                      ║
73   ║     sudo npx playwright install-deps                 ║
74   ║                                                      ║
75   ║ Alternatively, use apt:                              ║
76   ║     sudo apt-get install libavif13                   ║
77   ║                                                      ║
78   ║ <3 Playwright Team                                   ║
79   ╚══════════════════════════════════════════════════════╝
80       at validateDependenciesLinux (/home/workflows/workspace/node_modules/playwright-core/lib/server/registry/dependencies.js:216:9)
81       at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
82       at async Registry._validateHostRequirements (/home/workflows/workspace/node_modules/playwright-core/lib/server/registry/index.js:753:43)
83       at async Registry._validateHostRequirementsForExecutableIfNeeded (/home/workflows/workspace/node_modules/playwright-core/lib/server/registry/index.js:851:7)
84       at async Registry.validateHostRequirementsForExecutablesIfNeeded (/home/workflows/workspace/node_modules/playwright-core/lib/server/registry/index.js:840:43)
85       at async t.<anonymous> (/home/workflows/workspace/node_modules/playwright-core/lib/cli/program.js:137:7)
86   Detected missing Playwright dependencies. Attempting manual install...
87   Installing Playwright dependencies:
88   sudo apt-get install libavif13 -y
```