### PR TITLE
include path in cache hash calculation

### DIFF
--- a/workflow-steps/cache/hashing-utils.ts
+++ b/workflow-steps/cache/hashing-utils.ts
@@ -59,7 +59,10 @@ function tildePathToRelative(cachedFolderPath: string) {
   return cachedFolderPath;
 }
 
-export function buildCachePaths(inputPaths: string) {
+export function buildCachePaths(
+  inputPaths: string,
+  warnInvalidPaths: boolean = true,
+) {
   const directories = Array.from(
     new Set(
       inputPaths
@@ -74,7 +77,7 @@ export function buildCachePaths(inputPaths: string) {
   );
 
   const invalidDirectories = directories.filter((dir) => !fs.existsSync(dir));
-  if (invalidDirectories.length > 0) {
+  if (invalidDirectories.length > 0 && warnInvalidPaths) {
     console.warn(
       `The following paths are not valid or empty:\n${invalidDirectories.join(
         '\n',

--- a/workflow-steps/cache/output/main.js
+++ b/workflow-steps/cache/output/main.js
@@ -5992,7 +5992,7 @@ function hash(input) {
 function buildCachePaths(inputPaths2, warnInvalidPaths = true) {
   const directories = Array.from(
     new Set(
-      inputPaths2.split("\n").filter((p) => p).map((p) => p.replace(/^~/, "..")).reduce(
+      inputPaths2.split("\n").filter((p) => p).reduce(
         (allPaths, currPath) => [...allPaths, ...expandPath(currPath)],
         []
       )

--- a/workflow-steps/cache/output/main.js
+++ b/workflow-steps/cache/output/main.js
@@ -5989,10 +5989,17 @@ function hashKey(key2) {
 function hash(input) {
   return crypto.createHash("sha256").update(input).digest("hex");
 }
+function tildePathToRelative(cachedFolderPath) {
+  if (cachedFolderPath.startsWith("~")) {
+    const expandedPath = cachedFolderPath.replace(/^~/, os.homedir());
+    return path.relative(process.cwd(), expandedPath);
+  }
+  return cachedFolderPath;
+}
 function buildCachePaths(inputPaths2, warnInvalidPaths = true) {
   const directories = Array.from(
     new Set(
-      inputPaths2.split("\n").filter((p) => p).reduce(
+      inputPaths2.split("\n").filter((p) => p).map((p) => tildePathToRelative(p)).reduce(
         (allPaths, currPath) => [...allPaths, ...expandPath(currPath)],
         []
       )

--- a/workflow-steps/cache/post.ts
+++ b/workflow-steps/cache/post.ts
@@ -4,8 +4,8 @@ import { CacheService } from './generated_protos/cache_connect';
 import { StoreRequest, StoreResponse } from './generated_protos/cache_pb';
 import { buildCachePaths, hashKey } from './hashing-utils';
 
-const input_key = process.env.NX_CLOUD_INPUT_key;
-const input_paths = process.env.NX_CLOUD_INPUT_paths;
+const inputKey = process.env.NX_CLOUD_INPUT_key;
+const inputPaths = process.env.NX_CLOUD_INPUT_paths;
 
 const stepGroupId = process.env.NX_STEP_GROUP_ID
   ? process.env.NX_STEP_GROUP_ID.replace(/-/g, '_')
@@ -22,13 +22,12 @@ if (!!cacheWasHit) {
     }),
   );
 
-  if (!input_key || !input_paths) {
-    throw new Error('No cache restore key or paths provided.');
-  }
-  const key = hashKey(input_key);
-  const paths = buildCachePaths(input_paths);
+  const paths = buildCachePaths(inputPaths);
+  const stringifiedPaths = paths.join(',');
+  const key = hashKey(`${inputKey}|${stringifiedPaths}`);
 
   console.log('Storing the following directories..\n' + paths.join('\n'));
+  console.log(`\nUsing key..${key}`);
 
   cacheClient
     .storeV2(

--- a/workflow-steps/install-node-modules/main.js
+++ b/workflow-steps/install-node-modules/main.js
@@ -1,5 +1,6 @@
 const { execSync } = require('child_process');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { platform } = require('os');
 
 async function main() {
   const command = getInstallCommand();
@@ -27,7 +28,7 @@ async function runCommandWithRetries(command, maxRetries) {
 
   while (retryCount < maxRetries) {
     try {
-      execSync(command);
+      execSync(command, { stdio: 'inherit' });
       patchJest();
       console.log('Installed dependencies successfully!');
       break;

--- a/workflow-steps/install-node-modules/main.js
+++ b/workflow-steps/install-node-modules/main.js
@@ -1,6 +1,5 @@
 const { execSync } = require('child_process');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
-const { platform } = require('os');
 
 async function main() {
   const command = getInstallCommand();


### PR DESCRIPTION
Currently, if the `paths:` get reconfigured for the caching step but they `key` stays the same, the caching step will keep pulling in the old folder until the key gets invalidated naturally.

This ensures someone can't get in that state, and it also includes the paths in the hash calculation.