### PR TITLE
fix(workflows): Add arg for pnpm version

### DIFF
--- a/workflow-steps/install-node/main.yaml
+++ b/workflow-steps/install-node/main.yaml
@@ -4,6 +4,10 @@ inputs:
   - name: node_version
     description: 'The node version to be installed'
 
+  - name: pnpm_version
+    description: 'The pnpm version to be installed'
+    default: '8'
+
 definition:
   using: 'node'
   main: workflow-steps/install-node/main.js


### PR DESCRIPTION
Nx repo uses pnpm 9.8 but it also would like to indicate what version of node it would like to be installed.

Currently, this is not possible because:
- the workflow installs pnpm 
- The pnpm version is 8 which conflicts with the format for Nx repo's`pnpm-lock.yaml` which is v9

Ref: https://staging.nx.app/cipes/680fb1308d60733291c472f0?step=5ef16305-d593-40c5-b09c-ed3ad7389715&runGroup=&launchTemplate=linux-medium#step-list-pane
