### PR TITLE
fix(launch-templates): add patches directories to cache key in linux template

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -12,7 +12,7 @@ common-js-init-steps: &common-js-init-steps
   - name: Restore Node Modules Cache
     uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
     inputs:
-      key: 'package-lock.json|yarn.lock|pnpm-lock.yaml'
+      key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|patches/**|.yarn/patches/**'
       paths: 'node_modules'
       base-branch: 'main'
   - name: Restore Browser Binary Cache


### PR DESCRIPTION
- Include patches directories in the Node Modules Cache key
    - `patches` => patch-package, pnpm 
    - `.yarn/patches` => yarn


docs change: https://github.com/nrwl/nx/pull/32454

Related to DOC-152
