### PR TITLE
fix(install-browsers): stop hanging on silent playwright install

### DIFF
--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -1,5 +1,5 @@
 //@ts-check
-const { execSync, exec } = require('child_process');
+const { execSync } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 
 main().catch((error) => {
@@ -26,51 +26,9 @@ async function main() {
 
   if (hasPlaywright) {
     console.log('Installing browsers required by Playwright');
-    try {
-      const output = await runCmdAsync(
-        `${getPackageManagerCommand()} playwright install`,
-      );
-
-      // we can special handle missing deps for failed install
-      if (output.code !== 0 && output.stderr.includes('apt-get install')) {
-        console.log(
-          '\nDetected missing Playwright dependencies. Attempting manual install...',
-        );
-        // playwright has detected out of sync dependencies on the host machine, we we'll try to manually install them to prevent hard to debug failures
-        const [installCommand] =
-          output.stderr.match(/apt-get install (\b\w+\b )+/gi) || [];
-        if (installCommand) {
-          const depsInstalled = installDeps(`sudo ${installCommand.trim()} -y`);
-          if (!depsInstalled) {
-            console.error(
-              'Failed to install system dependencies for Playwright.',
-            );
-            process.exit(1);
-          }
-          console.log('Re-attempting to install browsers...');
-          const reattempt = await runCmdAsync(`${getPackageManagerCommand()}  playwright install`);
-          if (reattempt.code !== 0) {
-            console.error(
-              'Failed to install Playwright browsers after installing system dependencies.',
-            );
-            process.exit(reattempt.code);
-          }
-          console.log('Successfully installed Playwright browsers.');
-        } else {
-          console.error('Unable to handle failure automatically.');
-          process.exit(output.code);
-        }
-      } else if (output.code !== 0) {
-        console.error(
-          'There was an issue installing Playwright browsers. See above logs.',
-        );
-        process.exit(output.code);
-      }
-    } catch (e) {
-      console.error(e);
-      console.error('There is an issue installing Playwright dependencies');
-      process.exit(1);
-    }
+    execSync(`${getPackageManagerCommand()} playwright install`, {
+      stdio: 'inherit',
+    });
   }
 
   if (hasCypress) {
@@ -82,36 +40,6 @@ async function main() {
   console.log('Done');
 }
 
-/**
- * @param {string} cmd
- * @returns {Promise<{ stdout: string; stderr: string; code: number | null; }>}
- */
-async function runCmdAsync(cmd) {
-  return new Promise((res, reject) => {
-    let stdout = '';
-    let stderr = '';
-    const proc = exec(cmd);
-
-    proc?.stdout?.on('data', (data) => {
-      stdout += data.toString();
-      process.stdout.write(data);
-    });
-
-    proc?.stderr?.on('data', (data) => {
-      stderr += data.toString();
-      process.stderr.write(data);
-    });
-
-    proc.on('error', (error) => {
-      reject(error);
-    });
-
-    proc.on('close', (code) => {
-      res({ stdout, stderr, code });
-    });
-  });
-}
-
 function getPackageManagerCommand() {
   if (existsSync('package-lock.json')) {
     return 'npx';
@@ -119,24 +47,5 @@ function getPackageManagerCommand() {
     return 'yarn';
   } else if (existsSync('pnpm-lock.yaml') || existsSync('pnpm-lock.yml')) {
     return 'pnpm exec';
-  }
-}
-
-/**
- * @param {string} installCommand
- * @returns {boolean} true if installation succeeded, false otherwise
- */
-function installDeps(installCommand) {
-  try {
-    console.log(`Running "${installCommand}"`);
-    execSync(installCommand.trim(), { stdio: 'inherit' });
-    return true;
-  } catch (installError) {
-    console.error('There was an issue installing dependencies for Playwright.');
-    console.log(
-      'You can create a custom launch template and add a step to manually install the missing Playwright dependencies in order to get around this error.',
-    );
-    console.log('See docs here: https://nx.dev/ci/reference/launch-templates');
-    return false;
   }
 }

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -4,7 +4,7 @@ const { existsSync, readFileSync } = require('fs');
 
 main().catch((error) => {
   console.error('Unexpected error:', error);
-  process.exit(1);
+  process.exit(typeof error?.status === 'number' ? error.status : 1);
 });
 
 async function main() {
@@ -26,18 +26,61 @@ async function main() {
 
   if (hasPlaywright) {
     console.log('Installing browsers required by Playwright');
-    execSync(`${getPackageManagerCommand()} playwright install`, {
-      stdio: 'inherit',
-    });
+    await runWithRetries(`${getPackageManagerCommand()} playwright install`);
   }
 
   if (hasCypress) {
     console.log('Installing browsers required by Cypress');
-    execSync(`${getPackageManagerCommand()} cypress install`, {
-      stdio: 'inherit',
-    });
+    await runWithRetries(`${getPackageManagerCommand()} cypress install`);
   }
   console.log('Done');
+}
+
+/**
+ * Run `command` via execSync with stdio inherited, retrying on any failure
+ * (non-zero exit, signal, or per-attempt timeout) until either `maxRetries`
+ * is hit or a 10-minute total deadline elapses across all attempts.
+ *
+ * @param {string} command
+ */
+async function runWithRetries(command) {
+  const maxRetries = Number(process.env.NX_CLOUD_INPUT_max_retries) || 3;
+  const deadline = Date.now() + 600_000;
+  let retryCount = 0;
+
+  while (retryCount < maxRetries) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`Timed out running "${command}" after 10 minutes`);
+    }
+
+    try {
+      execSync(command, {
+        stdio: 'inherit',
+        timeout: remaining,
+        killSignal: 'SIGKILL',
+      });
+      return;
+    } catch (e) {
+      retryCount++;
+
+      if (retryCount >= maxRetries || Date.now() >= deadline) {
+        throw e;
+      }
+
+      const delay = Math.max(
+        3_000,
+        Math.pow(2, retryCount) * Math.random() * 1_250,
+      );
+      console.log(
+        `Installing browsers failed. Retrying install in ${(
+          delay / 1000
+        ).toFixed(0)} seconds...`,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
 }
 
 function getPackageManagerCommand() {

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -1,5 +1,5 @@
 //@ts-check
-const { execSync } = require('child_process');
+const { execSync, spawn } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 
 main().catch((error) => {
@@ -15,13 +15,7 @@ async function main() {
     return;
   }
 
-  let json;
-  try {
-    json = JSON.parse(readFileSync('package.json').toString());
-  } catch (e) {
-    console.log('Unable to parse package.json; skipping browser install.');
-    return;
-  }
+  const json = JSON.parse(readFileSync('package.json').toString());
 
   const hasPlaywright =
     (json.dependencies || {}).hasOwnProperty('@playwright/test') ||
@@ -54,25 +48,16 @@ async function runWithRetries(command) {
 
   while (retryCount < maxRetries) {
     try {
-      execSync(command, {
-        stdio: ['inherit', 'inherit', 'pipe'],
-        timeout: PER_ATTEMPT_TIMEOUT_MS,
-        killSignal: 'SIGKILL',
-      });
+      await runOnce(command);
       return;
     } catch (e) {
-      if (e?.stderr) {
-        process.stderr.write(e.stderr);
-      }
       retryCount++;
 
       if (retryCount >= maxRetries) {
         throw e;
       }
 
-      const aptRecovered = tryInstallMissingDeps(
-        e?.stderr ? e.stderr.toString() : '',
-      );
+      const aptRecovered = tryInstallMissingDeps(e?.stderr || '');
 
       if (aptRecovered) {
         console.log('Re-attempting install...');
@@ -92,6 +77,41 @@ async function runWithRetries(command) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
+}
+
+/**
+ * @param {string} command
+ * @returns {Promise<void>}
+ */
+function runOnce(command) {
+  return new Promise((resolve, reject) => {
+    let stderr = '';
+    const child = spawn(command, {
+      shell: true,
+      stdio: ['inherit', 'inherit', 'pipe'],
+      timeout: PER_ATTEMPT_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      process.stderr.write(chunk);
+    });
+    child.on('error', (err) => {
+      reject(Object.assign(err, { stderr }));
+    });
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const err = new Error(
+        signal
+          ? `Command killed by ${signal}: ${command}`
+          : `Command failed with exit code ${code}: ${command}`,
+      );
+      reject(Object.assign(err, { status: code, signal, stderr }));
+    });
+  });
 }
 
 /**

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -46,15 +46,6 @@ async function main() {
 const PER_ATTEMPT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Run `command` via execSync, retrying on any failure up to `maxRetries`
- * times. Each attempt is bounded by PER_ATTEMPT_TIMEOUT_MS so a silent hang
- * gets killed and retried rather than blocking forever.
- *
- * stderr is captured so we can detect playwright's "apt-get install <pkg>"
- * hint and auto-install missing system deps before the next retry; the
- * captured stderr is also written through to the parent so it still appears
- * in workflow logs.
- *
  * @param {string} command
  */
 async function runWithRetries(command) {
@@ -104,10 +95,6 @@ async function runWithRetries(command) {
 }
 
 /**
- * If the failed install's stderr asks the user to `apt-get install <pkg>`,
- * try to run it with sudo. Returns true if the install succeeded (so the
- * caller can retry immediately without backoff).
- *
  * @param {string} stderrText
  * @returns {boolean}
  */

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -15,7 +15,14 @@ async function main() {
     return;
   }
 
-  const json = JSON.parse(readFileSync('package.json').toString());
+  let json;
+  try {
+    json = JSON.parse(readFileSync('package.json').toString());
+  } catch (e) {
+    console.log('Unable to parse package.json; skipping browser install.');
+    return;
+  }
+
   const hasPlaywright =
     (json.dependencies || {}).hasOwnProperty('@playwright/test') ||
     (json.devDependencies || {}).hasOwnProperty('@playwright/test');
@@ -36,36 +43,49 @@ async function main() {
   console.log('Done');
 }
 
+const PER_ATTEMPT_TIMEOUT_MS = 5 * 60 * 1000;
+
 /**
- * Run `command` via execSync with stdio inherited, retrying on any failure
- * (non-zero exit, signal, or per-attempt timeout) until either `maxRetries`
- * is hit or a 10-minute total deadline elapses across all attempts.
+ * Run `command` via execSync, retrying on any failure up to `maxRetries`
+ * times. Each attempt is bounded by PER_ATTEMPT_TIMEOUT_MS so a silent hang
+ * gets killed and retried rather than blocking forever.
+ *
+ * stderr is captured so we can detect playwright's "apt-get install <pkg>"
+ * hint and auto-install missing system deps before the next retry; the
+ * captured stderr is also written through to the parent so it still appears
+ * in workflow logs.
  *
  * @param {string} command
  */
 async function runWithRetries(command) {
   const maxRetries = Number(process.env.NX_CLOUD_INPUT_max_retries) || 3;
-  const deadline = Date.now() + 600_000;
   let retryCount = 0;
 
   while (retryCount < maxRetries) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      throw new Error(`Timed out running "${command}" after 10 minutes`);
-    }
-
     try {
       execSync(command, {
-        stdio: 'inherit',
-        timeout: remaining,
+        stdio: ['inherit', 'inherit', 'pipe'],
+        timeout: PER_ATTEMPT_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
       return;
     } catch (e) {
+      if (e?.stderr) {
+        process.stderr.write(e.stderr);
+      }
       retryCount++;
 
-      if (retryCount >= maxRetries || Date.now() >= deadline) {
+      if (retryCount >= maxRetries) {
         throw e;
+      }
+
+      const aptRecovered = tryInstallMissingDeps(
+        e?.stderr ? e.stderr.toString() : '',
+      );
+
+      if (aptRecovered) {
+        console.log('Re-attempting install...');
+        continue;
       }
 
       const delay = Math.max(
@@ -80,6 +100,36 @@ async function runWithRetries(command) {
 
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
+  }
+}
+
+/**
+ * If the failed install's stderr asks the user to `apt-get install <pkg>`,
+ * try to run it with sudo. Returns true if the install succeeded (so the
+ * caller can retry immediately without backoff).
+ *
+ * @param {string} stderrText
+ * @returns {boolean}
+ */
+function tryInstallMissingDeps(stderrText) {
+  if (!stderrText.includes('apt-get install')) return false;
+  const [installCommand] =
+    stderrText.match(/apt-get install (\b\w+\b )+/gi) || [];
+  if (!installCommand) return false;
+
+  console.log(
+    '\nDetected missing system dependencies. Attempting manual install...',
+  );
+  try {
+    execSync(`sudo ${installCommand.trim()} -y`, { stdio: 'inherit' });
+    return true;
+  } catch {
+    console.error('Failed to install system dependencies for the browser.');
+    console.log(
+      'You can create a custom launch template and add a step to manually install the missing dependencies in order to get around this error.',
+    );
+    console.log('See docs here: https://nx.dev/ci/reference/launch-templates');
+    return false;
   }
 }
 


### PR DESCRIPTION

- Download hits 100%, then silence; runner kills after 10m no-output
- Root cause: async `exec` pipes stdio; playwright spawns helpers (npx wrapper, unzip, host validators) that inherit those pipe fds and outlive the immediate child, so the `'close'` event never fires

this PR:
- Drop the pipes: `execSync` with `stdio: 'inherit'`
- Matches the Cypress branch directly below and every other install step in this repo (`install-aws-cli`, `install-mise`, `install-node`, `install-node-modules`)
- No pipes to wait on, output streams live, file shrinks from ~250 → ~35 lines
