### PR TITLE
fix(install-browsers): ensure correct package manager is used for installation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,13 +1,8 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
-    "build": {
-      "outputs": ["{projectRoot}/output"],
-      "cache": true
-    },
-    "test": {
-      "cache": true
-    }
+    "build": { "outputs": ["{projectRoot}/output"], "cache": true },
+    "test": { "cache": true }
   },
   "nxCloudUrl": "https://staging.nx.app",
   "nxCloudId": "663100748f38641f0184bd8f",
@@ -16,10 +11,7 @@
       {
         "rule": "./scripts/validate-launch-template-urls/check-urls-resolve.ts"
       },
-      {
-        "rule": "./scripts/validate-launch-templates-schema/check-schemas.ts"
-      }
+      { "rule": "./scripts/validate-launch-templates-schema/check-schemas.ts" }
     ]
-  },
-  "analytics": true
+  }
 }

--- a/nx.json
+++ b/nx.json
@@ -1,8 +1,13 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
-    "build": { "outputs": ["{projectRoot}/output"], "cache": true },
-    "test": { "cache": true }
+    "build": {
+      "outputs": ["{projectRoot}/output"],
+      "cache": true
+    },
+    "test": {
+      "cache": true
+    }
   },
   "nxCloudUrl": "https://staging.nx.app",
   "nxCloudId": "663100748f38641f0184bd8f",
@@ -11,7 +16,10 @@
       {
         "rule": "./scripts/validate-launch-template-urls/check-urls-resolve.ts"
       },
-      { "rule": "./scripts/validate-launch-templates-schema/check-schemas.ts" }
+      {
+        "rule": "./scripts/validate-launch-templates-schema/check-schemas.ts"
+      }
     ]
-  }
+  },
+  "analytics": true
 }

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -27,7 +27,9 @@ async function main() {
   if (hasPlaywright) {
     console.log('Installing browsers required by Playwright');
     try {
-      const output = await runCmdAsync('npx playwright install');
+      const output = await runCmdAsync(
+        `${getPackageManagerCommand()} playwright install`,
+      );
 
       // we can special handle missing deps for failed install
       if (output.code !== 0 && output.stderr.includes('apt-get install')) {
@@ -73,7 +75,9 @@ async function main() {
 
   if (hasCypress) {
     console.log('Installing browsers required by Cypress');
-    execSync('npx cypress install', { stdio: 'inherit' });
+    execSync(`${getPackageManagerCommand()} cypress install`, {
+      stdio: 'inherit',
+    });
   }
   console.log('Done');
 }
@@ -106,6 +110,27 @@ async function runCmdAsync(cmd) {
       res({ stdout, stderr, code });
     });
   });
+}
+
+function getPackageManagerCommand() {
+  if (existsSync('package-lock.json')) {
+    return 'npx';
+  } else if (existsSync('yarn.lock')) {
+    const [major] = execSync(`yarn --version`, {
+      encoding: 'utf-8',
+    })
+      .trim()
+      .split('.');
+
+    const useBerry = +major >= 2;
+    if (useBerry) {
+      return 'yarn dlx';
+    } else {
+      return 'npx';
+    }
+  } else if (existsSync('pnpm-lock.yaml') || existsSync('pnpm-lock.yml')) {
+    return 'pnpm dlx';
+  }
 }
 
 /**

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -48,7 +48,7 @@ async function main() {
             process.exit(1);
           }
           console.log('Re-attempting to install browsers...');
-          const reattempt = await runCmdAsync('npx playwright install');
+          const reattempt = await runCmdAsync(`${getPackageManagerCommand()}  playwright install`);
           if (reattempt.code !== 0) {
             console.error(
               'Failed to install Playwright browsers after installing system dependencies.',
@@ -116,20 +116,9 @@ function getPackageManagerCommand() {
   if (existsSync('package-lock.json')) {
     return 'npx';
   } else if (existsSync('yarn.lock')) {
-    const [major] = execSync(`yarn --version`, {
-      encoding: 'utf-8',
-    })
-      .trim()
-      .split('.');
-
-    const useBerry = +major >= 2;
-    if (useBerry) {
-      return 'yarn dlx';
-    } else {
-      return 'npx';
-    }
+    return 'yarn';
   } else if (existsSync('pnpm-lock.yaml') || existsSync('pnpm-lock.yml')) {
-    return 'pnpm dlx';
+    return 'pnpm exec';
   }
 }
 

--- a/workflow-steps/install-browsers/main.yaml
+++ b/workflow-steps/install-browsers/main.yaml
@@ -1,5 +1,5 @@
 name: Install Browsers
-description: Installs browsers for Playwright
+description: Installs browsers for Playwright and Cypress
 
 definition:
   using: 'node'


### PR DESCRIPTION
Browser installation fails when using devEngines:

```
npm error code EBADDEVENGINES
3     npm error EBADDEVENGINES The developer of this package has specified the following through devEngines
4     npm error EBADDEVENGINES Invalid devEngines.packageManager
5     npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
6     npm error EBADDEVENGINES {
7     npm error EBADDEVENGINES   current: { name: 'npm', version: '11.6.2' },
8     npm error EBADDEVENGINES   required: { name: 'pnpm', version: '11.0.8', onFail: 'download' }
9     npm error EBADDEVENGINES }
10    npm error A complete log of this run can be found in: /home/workflows/.npm/_logs/2026-05-25T20_07_35_208Z-debug-0.log
```

The step should be using correct package manager.