### PR TITLE
fix(install-browsers): add idle + absolute timeouts and surface playw…

### DIFF
--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -2,6 +2,11 @@
 const { execSync, exec } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 
+const IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+const ABSOLUTE_TIMEOUT_MS = 5 * 60 * 1000;
+const KILL_GRACE_MS = 5_000;
+const DEBUG_NAMESPACES = 'pw:install';
+
 main().catch((error) => {
   console.error('Unexpected error:', error);
   process.exit(1);
@@ -25,7 +30,9 @@ async function main() {
     (json.devDependencies || {}).hasOwnProperty('cypress');
 
   if (hasPlaywright) {
-    console.log('Installing browsers required by Playwright');
+    console.log(
+      `Installing browsers required by Playwright (idle-timeout=${IDLE_TIMEOUT_MS / 1000}s, absolute-timeout=${ABSOLUTE_TIMEOUT_MS / 1000}s)`,
+    );
     try {
       const output = await runCmdAsync(
         `${getPackageManagerCommand()} playwright install`,
@@ -53,17 +60,20 @@ async function main() {
             console.error(
               'Failed to install Playwright browsers after installing system dependencies.',
             );
+            printFailureContext(reattempt);
             process.exit(reattempt.code);
           }
           console.log('Successfully installed Playwright browsers.');
         } else {
           console.error('Unable to handle failure automatically.');
+          printFailureContext(output);
           process.exit(output.code);
         }
       } else if (output.code !== 0) {
         console.error(
           'There was an issue installing Playwright browsers. See above logs.',
         );
+        printFailureContext(output);
         process.exit(output.code);
       }
     } catch (e) {
@@ -84,32 +94,160 @@ async function main() {
 
 /**
  * @param {string} cmd
- * @returns {Promise<{ stdout: string; stderr: string; code: number | null; }>}
+ * @returns {Promise<{ stdout: string; stderr: string; code: number; killedByTimeout: boolean; killReason: string | null; }>}
  */
 async function runCmdAsync(cmd) {
   return new Promise((res, reject) => {
     let stdout = '';
     let stderr = '';
-    const proc = exec(cmd);
+    let killedByTimeout = false;
+    /** @type {string | null} */
+    let killReason = null;
+    /** @type {NodeJS.Timeout | null} */
+    let graceTimer = null;
+    /** @type {NodeJS.Timeout | null} */
+    let idleTimer = null;
+
+    const childEnv = { ...process.env };
+    childEnv.DEBUG = childEnv.DEBUG
+      ? `${childEnv.DEBUG},${DEBUG_NAMESPACES}`
+      : DEBUG_NAMESPACES;
+
+    const proc = exec(cmd, { env: childEnv });
+
+    function escalateKill() {
+      killedByTimeout = true;
+      try {
+        proc.kill('SIGTERM');
+      } catch (e) {
+        // already exited
+      }
+      process.stderr.write(
+        `\nInstall Browsers: sent SIGTERM. SIGKILL in ${KILL_GRACE_MS / 1000}s if still running.\n`,
+      );
+      graceTimer = setTimeout(() => {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          process.stderr.write(
+            `Install Browsers: grace expired, sending SIGKILL.\n`,
+          );
+          try {
+            proc.kill('SIGKILL');
+          } catch (e) {
+            // already exited
+          }
+        }
+      }, KILL_GRACE_MS);
+      graceTimer.unref();
+    }
+
+    const absoluteTimer = setTimeout(() => {
+      const seconds = Math.round(ABSOLUTE_TIMEOUT_MS / 1000);
+      killReason = `absolute timeout (${seconds}s elapsed)`;
+      process.stderr.write(
+        `\nInstall Browsers: \`${cmd}\` reached absolute timeout of ${seconds}s.\n`,
+      );
+      escalateKill();
+    }, ABSOLUTE_TIMEOUT_MS);
+    absoluteTimer.unref();
+
+    function resetIdleTimer() {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        const seconds = Math.round(IDLE_TIMEOUT_MS / 1000);
+        killReason = `idle timeout (no output for ${seconds}s)`;
+        process.stderr.write(
+          `\nInstall Browsers: \`${cmd}\` produced no output for ${seconds}s.\n`,
+        );
+        escalateKill();
+      }, IDLE_TIMEOUT_MS);
+      idleTimer.unref();
+    }
+    resetIdleTimer();
 
     proc?.stdout?.on('data', (data) => {
       stdout += data.toString();
       process.stdout.write(data);
+      resetIdleTimer();
     });
 
     proc?.stderr?.on('data', (data) => {
       stderr += data.toString();
       process.stderr.write(data);
+      resetIdleTimer();
     });
 
     proc.on('error', (error) => {
+      clearTimeout(absoluteTimer);
+      if (idleTimer) clearTimeout(idleTimer);
+      if (graceTimer) clearTimeout(graceTimer);
       reject(error);
     });
 
-    proc.on('close', (code) => {
-      res({ stdout, stderr, code });
+    proc.on('close', (code, signal) => {
+      clearTimeout(absoluteTimer);
+      if (idleTimer) clearTimeout(idleTimer);
+      if (graceTimer) clearTimeout(graceTimer);
+      const resolvedCode =
+        code !== null
+          ? code
+          : signal === 'SIGKILL'
+            ? 137
+            : signal === 'SIGTERM'
+              ? 143
+              : 1;
+      res({
+        stdout,
+        stderr,
+        code: resolvedCode,
+        killedByTimeout,
+        killReason,
+      });
     });
   });
+}
+
+/**
+ * @param {{ stdout: string; stderr: string; killedByTimeout: boolean; killReason: string | null; }} output
+ */
+function printFailureContext(output) {
+  if (output.killedByTimeout) {
+    console.error(`\nInstall Browsers: terminated by ${output.killReason}.`);
+  }
+  console.error(`Active node version: ${process.version}`);
+  const playwrightVersion = resolvePlaywrightVersion();
+  if (playwrightVersion) {
+    console.error(`Resolved playwright version: ${playwrightVersion}`);
+  }
+  const lastStdout = output.stdout.split('\n').filter(Boolean).slice(-10).join('\n');
+  const lastStderr = output.stderr.split('\n').filter(Boolean).slice(-10).join('\n');
+  if (lastStdout) {
+    console.error(`\nLast stdout lines:\n${lastStdout}`);
+  }
+  if (lastStderr) {
+    console.error(`\nLast stderr lines:\n${lastStderr}`);
+  }
+}
+
+/**
+ * @returns {string | null}
+ */
+function resolvePlaywrightVersion() {
+  const candidates = [
+    'node_modules/@playwright/test/package.json',
+    'node_modules/playwright/package.json',
+    'node_modules/playwright-core/package.json',
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (existsSync(candidate)) {
+        const v = JSON.parse(readFileSync(candidate, 'utf8'))?.version;
+        if (typeof v === 'string' && v) return v;
+      }
+    } catch (e) {
+      // try the next one
+    }
+  }
+  return null;
 }
 
 function getPackageManagerCommand() {

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -1,5 +1,5 @@
 //@ts-check
-const { execSync, exec } = require('child_process');
+const { execSync, spawn } = require('child_process');
 const { existsSync, readFileSync } = require('fs');
 
 const IDLE_TIMEOUT_MS = 3 * 60 * 1000;
@@ -113,28 +113,36 @@ async function runCmdAsync(cmd) {
       ? `${childEnv.DEBUG},${DEBUG_NAMESPACES}`
       : DEBUG_NAMESPACES;
 
-    const proc = exec(cmd, { env: childEnv });
+    // Use spawn (not exec) so that `detached: true` is actually honoured:
+    // exec ignores it. `detached: true` puts the shell — and everything it
+    // forks (pnpm, node, the playwright extract worker) — in its own process
+    // group so `process.kill(-pid, signal)` takes the whole tree down at
+    // once. A plain proc.kill() only signals `/bin/sh`, which doesn't
+    // propagate to the descendants.
+    const proc = spawn('sh', ['-c', cmd], { env: childEnv, detached: true });
+    const rootPid = proc.pid;
+
+    function killGroup(signal) {
+      if (!rootPid) return;
+      try {
+        process.kill(-rootPid, signal);
+      } catch (e) {
+        // process group already gone
+      }
+    }
 
     function escalateKill() {
       killedByTimeout = true;
-      try {
-        proc.kill('SIGTERM');
-      } catch (e) {
-        // already exited
-      }
+      killGroup('SIGTERM');
       process.stderr.write(
-        `\nInstall Browsers: sent SIGTERM. SIGKILL in ${KILL_GRACE_MS / 1000}s if still running.\n`,
+        `\nInstall Browsers: sent SIGTERM to process group ${rootPid}. SIGKILL in ${KILL_GRACE_MS / 1000}s if still running.\n`,
       );
       graceTimer = setTimeout(() => {
         if (proc.exitCode === null && proc.signalCode === null) {
           process.stderr.write(
-            `Install Browsers: grace expired, sending SIGKILL.\n`,
+            `Install Browsers: grace expired, sending SIGKILL to process group ${rootPid}.\n`,
           );
-          try {
-            proc.kill('SIGKILL');
-          } catch (e) {
-            // already exited
-          }
+          killGroup('SIGKILL');
         }
       }, KILL_GRACE_MS);
       graceTimer.unref();

--- a/workflow-steps/install-browsers/main.js
+++ b/workflow-steps/install-browsers/main.js
@@ -215,7 +215,7 @@ async function runCmdAsync(cmd) {
 }
 
 /**
- * @param {{ stdout: string; stderr: string; killedByTimeout: boolean; killReason: string | null; }} output
+ * @param {{ killedByTimeout: boolean; killReason: string | null; }} output
  */
 function printFailureContext(output) {
   if (output.killedByTimeout) {
@@ -225,14 +225,6 @@ function printFailureContext(output) {
   const playwrightVersion = resolvePlaywrightVersion();
   if (playwrightVersion) {
     console.error(`Resolved playwright version: ${playwrightVersion}`);
-  }
-  const lastStdout = output.stdout.split('\n').filter(Boolean).slice(-10).join('\n');
-  const lastStderr = output.stderr.split('\n').filter(Boolean).slice(-10).join('\n');
-  if (lastStdout) {
-    console.error(`\nLast stdout lines:\n${lastStdout}`);
-  }
-  if (lastStderr) {
-    console.error(`\nLast stderr lines:\n${lastStderr}`);
   }
 }
 


### PR DESCRIPTION
…right install failures

- 3min idle timeout, 5min absolute timeout, SIGTERM then SIGKILL after a 5s grace
- Inject DEBUG=pw:install into the child env so the extraction step actually logs progress
- On failure, print the active node version, resolved playwright version, and the last 10 lines of stdout/stderr so the cause of a hang is visible

Supersedes #121.