### PR TITLE
chore: enable pnpm trustPolicy no-downgrade for install-time provenance checks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - 'workflow-steps/*'
+
+trustPolicy: no-downgrade


### PR DESCRIPTION
Adds `trustPolicy: no-downgrade` to `pnpm-workspace.yaml` to enable pnpm's install-time supply-chain trust check. With this set, pnpm rejects a package at install time if its trust level has *decreased* versus a previous release (e.g. it lost provenance or trusted-publisher status), mitigating certain supply-chain attacks.

Requires pnpm >= 10.21.0 — this repo pins pnpm 10.33.0, so it takes effect immediately.

Part of a coordinated cross-repo change across nrwl pnpm-workspace repos via Polygraph.

Refs: https://pnpm.io/supply-chain-security

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/pnpm-trustpoly-53bf9ed6)
<!-- polygraph-session-end -->