### PR TITLE
fix(checkout): scrub credentials from git output

### DIFF
--- a/workflow-steps/checkout/main.test.ts
+++ b/workflow-steps/checkout/main.test.ts
@@ -45,15 +45,28 @@ describe('Git Checkout Utility', () => {
   });
 
   describe('credential scrubbing', () => {
-    test('scrubs credentials from repository URLs', () => {
+    test('scrubs credentials from the configured repository URL', () => {
+      process.env.GIT_REPOSITORY_URL =
+        'https://x-access-token:ghs_secret@github.com/nrwl/nx.git';
+
+      expect(
+        scrubSensitiveValues(`Repository: ${process.env.GIT_REPOSITORY_URL}`),
+      ).toBe('Repository: https://***:***@github.com/nrwl/nx.git');
+    });
+
+    test('does not scrub unrelated URLs', () => {
+      process.env.GIT_REPOSITORY_URL =
+        'https://token@github.com/nrwl/nx-cloud-workflows.git';
+
       expect(
         scrubSensitiveValues(
-          'https://x-access-token:ghs_secret@github.com/nrwl/nx.git',
+          'Repository: https://token@github.com/nrwl/different.git',
         ),
-      ).toBe('https://***@github.com/nrwl/nx.git');
+      ).toBe('Repository: https://token@github.com/nrwl/different.git');
     });
 
     test('scrubs credentials from streamed git output', async () => {
+      process.env.GIT_REPOSITORY_URL = 'https://token@github.com/nrwl/nx.git';
       const stderrSpy = jest
         .spyOn(process.stderr, 'write')
         .mockImplementation(() => true);

--- a/workflow-steps/checkout/main.test.ts
+++ b/workflow-steps/checkout/main.test.ts
@@ -11,6 +11,7 @@ import * as fsPromises from 'node:fs/promises';
 import {
   buildFetchCommand,
   classifyError,
+  createRepositoryUrlScrubber,
   detectPlatform,
   executeGitCommand,
   executeWithRetry,
@@ -18,7 +19,7 @@ import {
   GitCheckoutError,
   isMergeQueueRef,
   isPullRequestRef,
-  scrubSensitiveValues,
+  scrubRepositoryUrl,
   validateEnvironment,
   writeToNxCloudEnv,
 } from './main';
@@ -46,27 +47,27 @@ describe('Git Checkout Utility', () => {
 
   describe('credential scrubbing', () => {
     test('scrubs credentials from the configured repository URL', () => {
-      process.env.GIT_REPOSITORY_URL =
+      const repoUrl =
         'https://x-access-token:ghs_secret@github.com/nrwl/nx.git';
+      const scrubOutput = createRepositoryUrlScrubber(repoUrl);
 
-      expect(
-        scrubSensitiveValues(`Repository: ${process.env.GIT_REPOSITORY_URL}`),
-      ).toBe('Repository: https://***:***@github.com/nrwl/nx.git');
+      expect(scrubOutput(`Repository: ${repoUrl}`)).toBe(
+        'Repository: https://***:***@github.com/nrwl/nx.git',
+      );
     });
 
     test('does not scrub unrelated URLs', () => {
-      process.env.GIT_REPOSITORY_URL =
-        'https://token@github.com/nrwl/nx-cloud-workflows.git';
+      const repoUrl = 'https://token@github.com/nrwl/nx-cloud-workflows.git';
+      const scrubOutput = createRepositoryUrlScrubber(repoUrl);
 
       expect(
-        scrubSensitiveValues(
-          'Repository: https://token@github.com/nrwl/different.git',
-        ),
+        scrubOutput('Repository: https://token@github.com/nrwl/different.git'),
       ).toBe('Repository: https://token@github.com/nrwl/different.git');
     });
 
     test('scrubs credentials from streamed git output', async () => {
-      process.env.GIT_REPOSITORY_URL = 'https://token@github.com/nrwl/nx.git';
+      const repoUrl = 'https://token@github.com/nrwl/nx.git';
+      const scrubOutput = createRepositoryUrlScrubber(repoUrl);
       const stderrSpy = jest
         .spyOn(process.stderr, 'write')
         .mockImplementation(() => true);
@@ -90,7 +91,7 @@ describe('Git Checkout Utility', () => {
       };
       mockSpawn.mockReturnValue(mockProcess as any);
 
-      await executeGitCommand('fetch', []);
+      await executeGitCommand('fetch', [], { scrubOutput });
 
       expect(stderrSpy).toHaveBeenCalledWith(
         'fatal: unable to access https://***@github.com/nrwl/nx.git',

--- a/workflow-steps/checkout/main.test.ts
+++ b/workflow-steps/checkout/main.test.ts
@@ -18,6 +18,7 @@ import {
   GitCheckoutError,
   isMergeQueueRef,
   isPullRequestRef,
+  scrubSensitiveValues,
   validateEnvironment,
   writeToNxCloudEnv,
 } from './main';
@@ -41,6 +42,49 @@ describe('Git Checkout Utility', () => {
   afterEach(() => {
     process.env = originalEnv;
     jest.useRealTimers();
+  });
+
+  describe('credential scrubbing', () => {
+    test('scrubs credentials from repository URLs', () => {
+      expect(
+        scrubSensitiveValues(
+          'https://x-access-token:ghs_secret@github.com/nrwl/nx.git',
+        ),
+      ).toBe('https://***@github.com/nrwl/nx.git');
+    });
+
+    test('scrubs credentials from streamed git output', async () => {
+      const stderrSpy = jest
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      const mockProcess = {
+        stdout: { on: jest.fn() },
+        stderr: {
+          on: jest.fn((event: string, callback: Function) => {
+            if (event === 'data') {
+              callback(
+                Buffer.from(
+                  'fatal: unable to access https://token@github.com/nrwl/nx.git',
+                ),
+              );
+            }
+          }),
+        },
+        on: jest.fn((event: string, callback: Function) => {
+          if (event === 'exit') callback(0, null);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+
+      await executeGitCommand('fetch', []);
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        'fatal: unable to access https://***@github.com/nrwl/nx.git',
+      );
+
+      stderrSpy.mockRestore();
+    });
   });
 
   describe('Environment validation', () => {

--- a/workflow-steps/checkout/main.ts
+++ b/workflow-steps/checkout/main.ts
@@ -141,8 +141,40 @@ class GitCheckoutError extends Error implements RetryableError {
   }
 }
 
-function scrubSensitiveValues(value: string): string {
-  return value.replace(/([a-z][a-z\d+.-]*:\/\/)([^@\s\/]+)@/gi, '$1***@');
+function scrubRepositoryUrl(repoUrl: string): string {
+  try {
+    const parsedUrl = new URL(repoUrl);
+    if (!parsedUrl.username && !parsedUrl.password) {
+      return repoUrl;
+    }
+
+    if (parsedUrl.username) {
+      parsedUrl.username = '***';
+    }
+    if (parsedUrl.password) {
+      parsedUrl.password = '***';
+    }
+
+    return parsedUrl.toString();
+  } catch {
+    return repoUrl;
+  }
+}
+
+function scrubSensitiveValues(
+  value: string,
+  sensitiveValue = process.env.GIT_REPOSITORY_URL,
+): string {
+  if (!sensitiveValue) {
+    return value;
+  }
+
+  const scrubbedValue = scrubRepositoryUrl(sensitiveValue);
+  if (scrubbedValue === sensitiveValue) {
+    return value;
+  }
+
+  return value.split(sensitiveValue).join(scrubbedValue);
 }
 
 /**
@@ -187,7 +219,7 @@ function validateEnvironment(): GitCheckoutConfig {
     }
   } catch {
     throw new GitCheckoutError(
-      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl)}`,
+      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl, repoUrl)}`,
       false,
     );
   }

--- a/workflow-steps/checkout/main.ts
+++ b/workflow-steps/checkout/main.ts
@@ -161,20 +161,15 @@ function scrubRepositoryUrl(repoUrl: string): string {
   }
 }
 
-function scrubSensitiveValues(
-  value: string,
-  sensitiveValue = process.env.GIT_REPOSITORY_URL,
-): string {
-  if (!sensitiveValue) {
-    return value;
-  }
+function createRepositoryUrlScrubber(
+  repoUrl: string,
+): (value: string) => string {
+  const scrubbedRepoUrl = scrubRepositoryUrl(repoUrl);
 
-  const scrubbedValue = scrubRepositoryUrl(sensitiveValue);
-  if (scrubbedValue === sensitiveValue) {
-    return value;
-  }
-
-  return value.split(sensitiveValue).join(scrubbedValue);
+  return (value) =>
+    scrubbedRepoUrl === repoUrl
+      ? value
+      : value.split(repoUrl).join(scrubbedRepoUrl);
 }
 
 /**
@@ -219,7 +214,7 @@ function validateEnvironment(): GitCheckoutConfig {
     }
   } catch {
     throw new GitCheckoutError(
-      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl, repoUrl)}`,
+      `Invalid GIT_REPOSITORY_URL: ${scrubRepositoryUrl(repoUrl)}`,
       false,
     );
   }
@@ -279,15 +274,19 @@ function validateEnvironment(): GitCheckoutConfig {
 async function executeGitCommand(
   command: string,
   args: string[],
-  options: { timeout?: number; cwd?: string; dryRun?: boolean } = {},
+  options: {
+    timeout?: number;
+    cwd?: string;
+    dryRun?: boolean;
+    scrubOutput?: (value: string) => string;
+  } = {},
 ): Promise<{ stdout: string; stderr: string }> {
   const fullArgs = [command, ...args];
+  const scrubOutput = options.scrubOutput || ((value: string) => value);
 
   if (options.dryRun) {
     console.log(
-      scrubSensitiveValues(
-        `[DRY RUN] Would execute: git ${fullArgs.join(' ')}`,
-      ),
+      scrubOutput(`[DRY RUN] Would execute: git ${fullArgs.join(' ')}`),
     );
     return { stdout: '', stderr: '' };
   }
@@ -310,7 +309,7 @@ async function executeGitCommand(
       stdout += output;
       // Show real-time progress for long-running operations
       if (command === 'fetch' || command === 'checkout') {
-        process.stdout.write(scrubSensitiveValues(output));
+        process.stdout.write(scrubOutput(output));
       }
     });
 
@@ -319,12 +318,12 @@ async function executeGitCommand(
       stderr += output;
       // Git often outputs progress to stderr
       if (command === 'fetch' || command === 'checkout') {
-        process.stderr.write(scrubSensitiveValues(output));
+        process.stderr.write(scrubOutput(output));
       }
     });
 
     child.on('error', (error) => {
-      reject(classifyError(error, command));
+      reject(classifyError(error, command, scrubOutput));
     });
 
     child.on('exit', (code, signal) => {
@@ -337,10 +336,7 @@ async function executeGitCommand(
         );
       } else if (code !== 0) {
         reject(
-          classifyError(
-            new Error(scrubSensitiveValues(stderr || stdout)),
-            command,
-          ),
+          classifyError(new Error(stderr || stdout), command, scrubOutput),
         );
       } else {
         resolve({ stdout, stderr });
@@ -355,8 +351,12 @@ async function executeGitCommand(
  * @param command The git command that failed
  * @returns A GitCheckoutError with isRetryable flag set appropriately
  */
-function classifyError(error: Error, command: string): GitCheckoutError {
-  const message = scrubSensitiveValues(error.message || error.toString());
+function classifyError(
+  error: Error,
+  command: string,
+  scrubOutput: (value: string) => string = (value) => value,
+): GitCheckoutError {
+  const message = scrubOutput(error.message || error.toString());
   const lowerMessage = message.toLowerCase();
 
   // Network and connection errors - retryable
@@ -627,9 +627,15 @@ async function main(): Promise<void> {
     console.error('Configuration error:', (error as Error).message);
     process.exit(1);
   }
+  const scrubOutput = createRepositoryUrlScrubber(config.repoUrl);
+  const executeGit = (
+    command: string,
+    args: string[],
+    options: { timeout?: number; cwd?: string; dryRun?: boolean } = {},
+  ) => executeGitCommand(command, args, { ...options, scrubOutput });
 
   console.log('Git checkout configuration:');
-  console.log(`  Repository: ${scrubSensitiveValues(config.repoUrl)}`);
+  console.log(`  Repository: ${scrubOutput(config.repoUrl)}`);
   console.log(`  Commit/Ref: ${config.commitSha}`);
   console.log(`  Branch: ${config.nxBranch}`);
   console.log(`  Depth: ${config.depth}`);
@@ -656,26 +662,22 @@ async function main(): Promise<void> {
      */
     if (process.platform !== 'win32') {
       const cwd = process.cwd();
-      await executeGitCommand(
-        'config',
-        ['--global', '--add', 'safe.directory', cwd],
-        {
-          timeout: config.timeout,
-          dryRun: config.dryRun,
-        },
-      );
+      await executeGit('config', ['--global', '--add', 'safe.directory', cwd], {
+        timeout: config.timeout,
+        dryRun: config.dryRun,
+      });
     }
 
     // Initialize repository
     console.log('Initializing git repository...');
-    await executeGitCommand('init', ['.'], {
+    await executeGit('init', ['.'], {
       timeout: config.timeout,
       dryRun: config.dryRun,
     });
 
     // Add remote
     console.log('Adding remote origin...');
-    await executeGitCommand('remote', ['add', 'origin', config.repoUrl], {
+    await executeGit('remote', ['add', 'origin', config.repoUrl], {
       timeout: config.timeout,
       dryRun: config.dryRun,
     });
@@ -688,7 +690,7 @@ async function main(): Promise<void> {
     const fetchArgs = buildFetchCommand(config);
     await executeWithRetry(
       () =>
-        executeGitCommand('fetch', fetchArgs, {
+        executeGit('fetch', fetchArgs, {
           timeout: config.timeout,
           dryRun: config.dryRun,
         }),
@@ -740,7 +742,7 @@ async function main(): Promise<void> {
     console.log(`Checking out ${checkoutTarget}...`);
     await executeWithRetry(
       () =>
-        executeGitCommand('checkout', checkoutArgs, {
+        executeGit('checkout', checkoutArgs, {
           timeout: config.timeout,
           dryRun: config.dryRun,
         }),
@@ -751,13 +753,9 @@ async function main(): Promise<void> {
     // Verify checkout (unless in dry-run mode)
     if (!config.dryRun) {
       console.log('Verifying checkout...');
-      const { stdout: currentSha } = await executeGitCommand(
-        'rev-parse',
-        ['HEAD'],
-        {
-          timeout: config.timeout,
-        },
-      );
+      const { stdout: currentSha } = await executeGit('rev-parse', ['HEAD'], {
+        timeout: config.timeout,
+      });
 
       const expectedSha =
         config.commitSha.startsWith('origin/') ||
@@ -784,7 +782,7 @@ async function main(): Promise<void> {
     if (gitError.originalError) {
       console.error(
         'Original error:',
-        scrubSensitiveValues(gitError.originalError.message),
+        scrubOutput(gitError.originalError.message),
       );
     }
     process.exit(1);
@@ -795,11 +793,12 @@ async function main(): Promise<void> {
 export {
   buildFetchCommand,
   classifyError,
+  createRepositoryUrlScrubber,
   executeGitCommand,
   executeWithRetry,
   GitCheckoutConfig,
   GitCheckoutError,
-  scrubSensitiveValues,
+  scrubRepositoryUrl,
   validateEnvironment,
   writeToNxCloudEnv,
 };

--- a/workflow-steps/checkout/main.ts
+++ b/workflow-steps/checkout/main.ts
@@ -141,6 +141,10 @@ class GitCheckoutError extends Error implements RetryableError {
   }
 }
 
+function scrubSensitiveValues(value: string): string {
+  return value.replace(/([a-z][a-z\d+.-]*:\/\/)([^@\s\/]+)@/gi, '$1***@');
+}
+
 /**
  * Validates and parses environment variables into a typed configuration
  * @throws {GitCheckoutError} If required environment variables are missing or invalid
@@ -182,7 +186,10 @@ function validateEnvironment(): GitCheckoutConfig {
       new URL(repoUrl);
     }
   } catch {
-    throw new GitCheckoutError(`Invalid GIT_REPOSITORY_URL: ${repoUrl}`, false);
+    throw new GitCheckoutError(
+      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl)}`,
+      false,
+    );
   }
 
   // Validate commit SHA format - allow SHAs, branch refs, and any valid git ref format
@@ -245,7 +252,11 @@ async function executeGitCommand(
   const fullArgs = [command, ...args];
 
   if (options.dryRun) {
-    console.log(`[DRY RUN] Would execute: git ${fullArgs.join(' ')}`);
+    console.log(
+      scrubSensitiveValues(
+        `[DRY RUN] Would execute: git ${fullArgs.join(' ')}`,
+      ),
+    );
     return { stdout: '', stderr: '' };
   }
 
@@ -267,7 +278,7 @@ async function executeGitCommand(
       stdout += output;
       // Show real-time progress for long-running operations
       if (command === 'fetch' || command === 'checkout') {
-        process.stdout.write(output);
+        process.stdout.write(scrubSensitiveValues(output));
       }
     });
 
@@ -276,7 +287,7 @@ async function executeGitCommand(
       stderr += output;
       // Git often outputs progress to stderr
       if (command === 'fetch' || command === 'checkout') {
-        process.stderr.write(output);
+        process.stderr.write(scrubSensitiveValues(output));
       }
     });
 
@@ -293,7 +304,12 @@ async function executeGitCommand(
           ),
         );
       } else if (code !== 0) {
-        reject(classifyError(new Error(stderr || stdout), command));
+        reject(
+          classifyError(
+            new Error(scrubSensitiveValues(stderr || stdout)),
+            command,
+          ),
+        );
       } else {
         resolve({ stdout, stderr });
       }
@@ -308,7 +324,7 @@ async function executeGitCommand(
  * @returns A GitCheckoutError with isRetryable flag set appropriately
  */
 function classifyError(error: Error, command: string): GitCheckoutError {
-  const message = error.message || error.toString();
+  const message = scrubSensitiveValues(error.message || error.toString());
   const lowerMessage = message.toLowerCase();
 
   // Network and connection errors - retryable
@@ -581,7 +597,7 @@ async function main(): Promise<void> {
   }
 
   console.log('Git checkout configuration:');
-  console.log(`  Repository: ${config.repoUrl}`);
+  console.log(`  Repository: ${scrubSensitiveValues(config.repoUrl)}`);
   console.log(`  Commit/Ref: ${config.commitSha}`);
   console.log(`  Branch: ${config.nxBranch}`);
   console.log(`  Depth: ${config.depth}`);
@@ -734,7 +750,10 @@ async function main(): Promise<void> {
     const gitError = error as GitCheckoutError;
     console.error('Git checkout failed:', gitError.message);
     if (gitError.originalError) {
-      console.error('Original error:', gitError.originalError.message);
+      console.error(
+        'Original error:',
+        scrubSensitiveValues(gitError.originalError.message),
+      );
     }
     process.exit(1);
   }
@@ -748,6 +767,7 @@ export {
   executeWithRetry,
   GitCheckoutConfig,
   GitCheckoutError,
+  scrubSensitiveValues,
   validateEnvironment,
   writeToNxCloudEnv,
 };

--- a/workflow-steps/checkout/output/main.js
+++ b/workflow-steps/checkout/output/main.js
@@ -28,6 +28,7 @@ __export(main_exports, {
   getPullRequestRefs: () => getPullRequestRefs,
   isMergeQueueRef: () => isMergeQueueRef,
   isPullRequestRef: () => isPullRequestRef,
+  scrubSensitiveValues: () => scrubSensitiveValues,
   validateEnvironment: () => validateEnvironment,
   writeToNxCloudEnv: () => writeToNxCloudEnv
 });
@@ -110,6 +111,9 @@ var GitCheckoutError = class extends Error {
     this.name = "GitCheckoutError";
   }
 };
+function scrubSensitiveValues(value) {
+  return value.replace(/([a-z][a-z\d+.-]*:\/\/)([^@\s\/]+)@/gi, "$1***@");
+}
 function validateEnvironment() {
   const repoUrl = process.env.GIT_REPOSITORY_URL;
   const commitSha = process.env.NX_COMMIT_SHA;
@@ -141,7 +145,10 @@ function validateEnvironment() {
       new URL(repoUrl);
     }
   } catch {
-    throw new GitCheckoutError(`Invalid GIT_REPOSITORY_URL: ${repoUrl}`, false);
+    throw new GitCheckoutError(
+      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl)}`,
+      false
+    );
   }
   if (!commitSha.match(
     /^[a-fA-F0-9]{6,40}$|^origin\/[\w\-\.\/]+$|^refs\/[\w\-\.\/]+$|^[\w\-\.\/]+\/\d+\/[\w\-]+$/i
@@ -181,7 +188,11 @@ function validateEnvironment() {
 async function executeGitCommand(command, args, options = {}) {
   const fullArgs = [command, ...args];
   if (options.dryRun) {
-    console.log(`[DRY RUN] Would execute: git ${fullArgs.join(" ")}`);
+    console.log(
+      scrubSensitiveValues(
+        `[DRY RUN] Would execute: git ${fullArgs.join(" ")}`
+      )
+    );
     return { stdout: "", stderr: "" };
   }
   return new Promise((resolve, reject) => {
@@ -198,14 +209,14 @@ async function executeGitCommand(command, args, options = {}) {
       const output = data.toString();
       stdout += output;
       if (command === "fetch" || command === "checkout") {
-        process.stdout.write(output);
+        process.stdout.write(scrubSensitiveValues(output));
       }
     });
     child.stderr?.on("data", (data) => {
       const output = data.toString();
       stderr += output;
       if (command === "fetch" || command === "checkout") {
-        process.stderr.write(output);
+        process.stderr.write(scrubSensitiveValues(output));
       }
     });
     child.on("error", (error) => {
@@ -220,7 +231,12 @@ async function executeGitCommand(command, args, options = {}) {
           )
         );
       } else if (code !== 0) {
-        reject(classifyError(new Error(stderr || stdout), command));
+        reject(
+          classifyError(
+            new Error(scrubSensitiveValues(stderr || stdout)),
+            command
+          )
+        );
       } else {
         resolve({ stdout, stderr });
       }
@@ -228,7 +244,7 @@ async function executeGitCommand(command, args, options = {}) {
   });
 }
 function classifyError(error, command) {
-  const message = error.message || error.toString();
+  const message = scrubSensitiveValues(error.message || error.toString());
   const lowerMessage = message.toLowerCase();
   if (lowerMessage.includes("connection") || lowerMessage.includes("timeout") || lowerMessage.includes("early eof") || lowerMessage.includes("network") || lowerMessage.includes("could not read from remote") || lowerMessage.includes("unable to access") || lowerMessage.includes("couldn't resolve host")) {
     return new GitCheckoutError(
@@ -409,7 +425,7 @@ async function main() {
     process.exit(1);
   }
   console.log("Git checkout configuration:");
-  console.log(`  Repository: ${config.repoUrl}`);
+  console.log(`  Repository: ${scrubSensitiveValues(config.repoUrl)}`);
   console.log(`  Commit/Ref: ${config.commitSha}`);
   console.log(`  Branch: ${config.nxBranch}`);
   console.log(`  Depth: ${config.depth}`);
@@ -513,7 +529,10 @@ async function main() {
     const gitError = error;
     console.error("Git checkout failed:", gitError.message);
     if (gitError.originalError) {
-      console.error("Original error:", gitError.originalError.message);
+      console.error(
+        "Original error:",
+        scrubSensitiveValues(gitError.originalError.message)
+      );
     }
     process.exit(1);
   }
@@ -535,6 +554,7 @@ if (require.main === module) {
   getPullRequestRefs,
   isMergeQueueRef,
   isPullRequestRef,
+  scrubSensitiveValues,
   validateEnvironment,
   writeToNxCloudEnv
 });

--- a/workflow-steps/checkout/output/main.js
+++ b/workflow-steps/checkout/output/main.js
@@ -22,13 +22,14 @@ __export(main_exports, {
   GitCheckoutError: () => GitCheckoutError,
   buildFetchCommand: () => buildFetchCommand,
   classifyError: () => classifyError,
+  createRepositoryUrlScrubber: () => createRepositoryUrlScrubber,
   detectPlatform: () => detectPlatform,
   executeGitCommand: () => executeGitCommand,
   executeWithRetry: () => executeWithRetry,
   getPullRequestRefs: () => getPullRequestRefs,
   isMergeQueueRef: () => isMergeQueueRef,
   isPullRequestRef: () => isPullRequestRef,
-  scrubSensitiveValues: () => scrubSensitiveValues,
+  scrubRepositoryUrl: () => scrubRepositoryUrl,
   validateEnvironment: () => validateEnvironment,
   writeToNxCloudEnv: () => writeToNxCloudEnv
 });
@@ -128,15 +129,9 @@ function scrubRepositoryUrl(repoUrl) {
     return repoUrl;
   }
 }
-function scrubSensitiveValues(value, sensitiveValue = process.env.GIT_REPOSITORY_URL) {
-  if (!sensitiveValue) {
-    return value;
-  }
-  const scrubbedValue = scrubRepositoryUrl(sensitiveValue);
-  if (scrubbedValue === sensitiveValue) {
-    return value;
-  }
-  return value.split(sensitiveValue).join(scrubbedValue);
+function createRepositoryUrlScrubber(repoUrl) {
+  const scrubbedRepoUrl = scrubRepositoryUrl(repoUrl);
+  return (value) => scrubbedRepoUrl === repoUrl ? value : value.split(repoUrl).join(scrubbedRepoUrl);
 }
 function validateEnvironment() {
   const repoUrl = process.env.GIT_REPOSITORY_URL;
@@ -170,7 +165,7 @@ function validateEnvironment() {
     }
   } catch {
     throw new GitCheckoutError(
-      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl, repoUrl)}`,
+      `Invalid GIT_REPOSITORY_URL: ${scrubRepositoryUrl(repoUrl)}`,
       false
     );
   }
@@ -211,11 +206,10 @@ function validateEnvironment() {
 }
 async function executeGitCommand(command, args, options = {}) {
   const fullArgs = [command, ...args];
+  const scrubOutput = options.scrubOutput || ((value) => value);
   if (options.dryRun) {
     console.log(
-      scrubSensitiveValues(
-        `[DRY RUN] Would execute: git ${fullArgs.join(" ")}`
-      )
+      scrubOutput(`[DRY RUN] Would execute: git ${fullArgs.join(" ")}`)
     );
     return { stdout: "", stderr: "" };
   }
@@ -233,18 +227,18 @@ async function executeGitCommand(command, args, options = {}) {
       const output = data.toString();
       stdout += output;
       if (command === "fetch" || command === "checkout") {
-        process.stdout.write(scrubSensitiveValues(output));
+        process.stdout.write(scrubOutput(output));
       }
     });
     child.stderr?.on("data", (data) => {
       const output = data.toString();
       stderr += output;
       if (command === "fetch" || command === "checkout") {
-        process.stderr.write(scrubSensitiveValues(output));
+        process.stderr.write(scrubOutput(output));
       }
     });
     child.on("error", (error) => {
-      reject(classifyError(error, command));
+      reject(classifyError(error, command, scrubOutput));
     });
     child.on("exit", (code, signal) => {
       if (signal === "SIGTERM" && options.timeout) {
@@ -256,10 +250,7 @@ async function executeGitCommand(command, args, options = {}) {
         );
       } else if (code !== 0) {
         reject(
-          classifyError(
-            new Error(scrubSensitiveValues(stderr || stdout)),
-            command
-          )
+          classifyError(new Error(stderr || stdout), command, scrubOutput)
         );
       } else {
         resolve({ stdout, stderr });
@@ -267,8 +258,8 @@ async function executeGitCommand(command, args, options = {}) {
     });
   });
 }
-function classifyError(error, command) {
-  const message = scrubSensitiveValues(error.message || error.toString());
+function classifyError(error, command, scrubOutput = (value) => value) {
+  const message = scrubOutput(error.message || error.toString());
   const lowerMessage = message.toLowerCase();
   if (lowerMessage.includes("connection") || lowerMessage.includes("timeout") || lowerMessage.includes("early eof") || lowerMessage.includes("network") || lowerMessage.includes("could not read from remote") || lowerMessage.includes("unable to access") || lowerMessage.includes("couldn't resolve host")) {
     return new GitCheckoutError(
@@ -448,8 +439,10 @@ async function main() {
     console.error("Configuration error:", error.message);
     process.exit(1);
   }
+  const scrubOutput = createRepositoryUrlScrubber(config.repoUrl);
+  const executeGit = (command, args, options = {}) => executeGitCommand(command, args, { ...options, scrubOutput });
   console.log("Git checkout configuration:");
-  console.log(`  Repository: ${scrubSensitiveValues(config.repoUrl)}`);
+  console.log(`  Repository: ${scrubOutput(config.repoUrl)}`);
   console.log(`  Commit/Ref: ${config.commitSha}`);
   console.log(`  Branch: ${config.nxBranch}`);
   console.log(`  Depth: ${config.depth}`);
@@ -467,22 +460,18 @@ async function main() {
   try {
     if (process.platform !== "win32") {
       const cwd = process.cwd();
-      await executeGitCommand(
-        "config",
-        ["--global", "--add", "safe.directory", cwd],
-        {
-          timeout: config.timeout,
-          dryRun: config.dryRun
-        }
-      );
+      await executeGit("config", ["--global", "--add", "safe.directory", cwd], {
+        timeout: config.timeout,
+        dryRun: config.dryRun
+      });
     }
     console.log("Initializing git repository...");
-    await executeGitCommand("init", ["."], {
+    await executeGit("init", ["."], {
       timeout: config.timeout,
       dryRun: config.dryRun
     });
     console.log("Adding remote origin...");
-    await executeGitCommand("remote", ["add", "origin", config.repoUrl], {
+    await executeGit("remote", ["add", "origin", config.repoUrl], {
       timeout: config.timeout,
       dryRun: config.dryRun
     });
@@ -490,7 +479,7 @@ async function main() {
     console.log("Fetching from remote...");
     const fetchArgs = buildFetchCommand(config);
     await executeWithRetry(
-      () => executeGitCommand("fetch", fetchArgs, {
+      () => executeGit("fetch", fetchArgs, {
         timeout: config.timeout,
         dryRun: config.dryRun
       }),
@@ -524,7 +513,7 @@ async function main() {
     }
     console.log(`Checking out ${checkoutTarget}...`);
     await executeWithRetry(
-      () => executeGitCommand("checkout", checkoutArgs, {
+      () => executeGit("checkout", checkoutArgs, {
         timeout: config.timeout,
         dryRun: config.dryRun
       }),
@@ -533,13 +522,9 @@ async function main() {
     );
     if (!config.dryRun) {
       console.log("Verifying checkout...");
-      const { stdout: currentSha } = await executeGitCommand(
-        "rev-parse",
-        ["HEAD"],
-        {
-          timeout: config.timeout
-        }
-      );
+      const { stdout: currentSha } = await executeGit("rev-parse", ["HEAD"], {
+        timeout: config.timeout
+      });
       const expectedSha = config.commitSha.startsWith("origin/") || config.commitSha.startsWith("pull/") ? currentSha.trim() : config.commitSha;
       if (!config.commitSha.startsWith("origin/") && !config.commitSha.startsWith("pull/") && !currentSha.trim().startsWith(expectedSha.substring(0, 7))) {
         throw new GitCheckoutError(
@@ -555,7 +540,7 @@ async function main() {
     if (gitError.originalError) {
       console.error(
         "Original error:",
-        scrubSensitiveValues(gitError.originalError.message)
+        scrubOutput(gitError.originalError.message)
       );
     }
     process.exit(1);
@@ -572,13 +557,14 @@ if (require.main === module) {
   GitCheckoutError,
   buildFetchCommand,
   classifyError,
+  createRepositoryUrlScrubber,
   detectPlatform,
   executeGitCommand,
   executeWithRetry,
   getPullRequestRefs,
   isMergeQueueRef,
   isPullRequestRef,
-  scrubSensitiveValues,
+  scrubRepositoryUrl,
   validateEnvironment,
   writeToNxCloudEnv
 });

--- a/workflow-steps/checkout/output/main.js
+++ b/workflow-steps/checkout/output/main.js
@@ -111,8 +111,32 @@ var GitCheckoutError = class extends Error {
     this.name = "GitCheckoutError";
   }
 };
-function scrubSensitiveValues(value) {
-  return value.replace(/([a-z][a-z\d+.-]*:\/\/)([^@\s\/]+)@/gi, "$1***@");
+function scrubRepositoryUrl(repoUrl) {
+  try {
+    const parsedUrl = new URL(repoUrl);
+    if (!parsedUrl.username && !parsedUrl.password) {
+      return repoUrl;
+    }
+    if (parsedUrl.username) {
+      parsedUrl.username = "***";
+    }
+    if (parsedUrl.password) {
+      parsedUrl.password = "***";
+    }
+    return parsedUrl.toString();
+  } catch {
+    return repoUrl;
+  }
+}
+function scrubSensitiveValues(value, sensitiveValue = process.env.GIT_REPOSITORY_URL) {
+  if (!sensitiveValue) {
+    return value;
+  }
+  const scrubbedValue = scrubRepositoryUrl(sensitiveValue);
+  if (scrubbedValue === sensitiveValue) {
+    return value;
+  }
+  return value.split(sensitiveValue).join(scrubbedValue);
 }
 function validateEnvironment() {
   const repoUrl = process.env.GIT_REPOSITORY_URL;
@@ -146,7 +170,7 @@ function validateEnvironment() {
     }
   } catch {
     throw new GitCheckoutError(
-      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl)}`,
+      `Invalid GIT_REPOSITORY_URL: ${scrubSensitiveValues(repoUrl, repoUrl)}`,
       false
     );
   }


### PR DESCRIPTION
Fixes CLOUD-4682.

This keeps the checkout step behavior unchanged but scrubs credentials embedded in repository URLs before writing logs or error messages.

Verification:
- pnpm --filter checkout-step test
- pnpm --filter checkout-step build
- git diff --check

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/scrub-log-output-228e9970)
<!-- polygraph-session-end -->

closes: CLOUD-4682