### PR TITLE
fix(install-mise): bump mise to v2026.7.7

### DIFF
--- a/workflow-steps/install-java-if-present/main.js
+++ b/workflow-steps/install-java-if-present/main.js
@@ -39,7 +39,7 @@ writeFileSync('mise.toml', `[tools]\njava = "${javaVersion}"\n`, {
 // --- inlined install-mise logic ---
 
 const miseGhVersion =
-  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2025.12.2';
+  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2026.7.7';
 const installArgs = process.env['NX_CLOUD_INPUT_install-args'] || '';
 
 const MISE_INSTALL_DIR = '$HOME/.local/bin';

--- a/workflow-steps/install-mise-if-present/main.js
+++ b/workflow-steps/install-mise-if-present/main.js
@@ -18,7 +18,7 @@ const runInstall = process.env['NX_CLOUD_INPUT_auto-install']
   ? process.env['NX_CLOUD_INPUT_auto-install'] === 'true'
   : true;
 const miseGhVersion =
-  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2025.12.2';
+  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2026.7.7';
 const installArgs = process.env['NX_CLOUD_INPUT_install-args'] || '';
 
 const MISE_INSTALL_DIR = '$HOME/.local/bin';

--- a/workflow-steps/install-mise/README.md
+++ b/workflow-steps/install-mise/README.md
@@ -4,7 +4,7 @@
 - name: Install mise
   uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
   inputs:
-    mise-version: 'v2025.10.19'
+    mise-version: 'v2026.7.7'
     auto-install: true
     tools: |
       rust=1.90
@@ -19,7 +19,7 @@ Auto run install tools after installing the mise cli. Defaults to `true`.
 
 #### mise-version
 
-Version of mise to use based on the [GitHub Releases](https://github.com/jdx/mise/releases). Defaults to `v2025.12.2`.
+Version of mise to use based on the [GitHub Releases](https://github.com/jdx/mise/releases). Defaults to `v2026.7.7`.
 
 #### install-args
 

--- a/workflow-steps/install-mise/main.js
+++ b/workflow-steps/install-mise/main.js
@@ -6,7 +6,7 @@ const runInstall = process.env['NX_CLOUD_INPUT_auto-install']
   ? process.env['NX_CLOUD_INPUT_auto-install'] === 'true'
   : true;
 const miseGhVersion =
-  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2025.12.2';
+  process.env['NX_CLOUD_INPUT_mise-version'] || 'v2026.7.7';
 const installArgs = process.env['NX_CLOUD_INPUT_install-args'] || '';
 const inlineToolDef = process.env['NX_CLOUD_INPUT_tools'] || '';
 
@@ -59,7 +59,7 @@ function retryWithBackoff(
 if (!miseGhVersion.startsWith('v')) {
   console.error(`Invalid mise_version: ${miseGhVersion}`);
   console.error(
-    `mise_version must start with 'v', e.g., 'v2025.10.19'. Got ${miseGhVersion}`,
+    `mise_version must start with 'v', e.g., 'v2026.7.7'. Got ${miseGhVersion}`,
   );
   console.error(
     'View available versions at https://github.com/jdx/mise/releases',

--- a/workflow-steps/install-mise/main.yaml
+++ b/workflow-steps/install-mise/main.yaml
@@ -6,7 +6,7 @@ inputs:
     default: true
   - name: mise-version
     description: 'Version of mise to use based on the GitHub Releases: https://github.com/jdx/mise/releases'
-    default: 'v2025.12.2'
+    default: 'v2026.7.7'
   - name: tools
     description: 'Inline definition of tools to be installed. Tools are defined by a newline separated list where each line defines a tool and version separated by a =, @ or space,`<name>=<version>. e.g. rust=1.90'
   - name: install-args


### PR DESCRIPTION
## What changed

- bump the public `install-mise` descriptor and runtime fallback from mise `v2025.12.2` to `v2026.7.7`
- bump the copied fallbacks in `install-mise-if-present` and `install-java-if-present`
- update the documented default and usage example

## Why

GitHub now serves artifact attestation bundles as Snappy-compressed responses. The sigstore verifier embedded in mise `v2025.12.2` attempts to decode those bytes directly as JSON, so Aqua-backed tools with required attestations fail during `mise install`.

mise added Snappy bundle support in `v2026.2.13`; `v2026.7.7` is the current release and successfully installs `zizmor@1.23.1` with artifact attestation verification enabled.

Fixes #131.

## Verification

- isolated mise `v2026.7.7` install of `zizmor@1.23.1`: passed with GitHub artifact attestations verified
- `node --check` on all three changed installer implementations: passed
- parsed `workflow-steps/install-mise/main.yaml` and asserted the new default: passed
- `pnpm run build-all`: passed
- `git diff --check`: passed

Prettier still reports the three installer JavaScript files as baseline-unformatted; formatting entire files was intentionally left out of this version-only fix.
