### PR TITLE
fix(launch-templates): update universal-large image to node 24 LTS

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -172,5 +172,5 @@ launch-templates:
     init-steps: *common-dotnet-init-steps
   universal-large:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-universal-init-steps


### PR DESCRIPTION
Updates the base image of the `universal-large` launch template — the template used by the polygraph index-repository workflow — from `ubuntu22.04-node20.19-v2` (Node 20.19) to `ubuntu22.04-node24.14-v1` (Node 24.14.1, the current Node LTS).

`ubuntu22.04-node24.14-v1` is a published Nx Cloud workflow image (see the launch-templates image list in the Nx docs). Per the image changelog, newer images include the changes from previous ones, so this also picks up the Docker and Playwright dependency updates from the intermediate tags.

Scope: only `universal-large` is changed. The js/jvm/dotnet templates intentionally stay on `ubuntu22.04-node20.19-v2`, as NXA-2215 covers only the polygraph index-repository base image.

Closes [NXA-2215](https://linear.app/nxdev/issue/NXA-2215/update-base-image-used-by-polygraph-index-repository-to-use-current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxa-2215-update-base-image-used-by-polygraph-index-repositor-0096124d">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->