### PR TITLE
fix(launch-templates): update all images to node 24 LTS

### DIFF
--- a/launch-templates/linux.yaml
+++ b/launch-templates/linux.yaml
@@ -88,87 +88,87 @@ common-universal-init-steps: &common-universal-init-steps
 launch-templates:
   linux-small-js:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-medium-plus-js:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-large-js:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-large-plus-js:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-extra-large-js:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-extra-large-plus-js:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-js-init-steps
   linux-small-jvm:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-medium-jvm:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-medium-plus-jvm:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-large-jvm:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-large-plus-jvm:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-extra-large-jvm:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-extra-large-plus-jvm:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-jvm-init-steps
   linux-small-dotnet:
     resource-class: 'docker_linux_amd64/small'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-medium-dotnet:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-medium-plus-dotnet:
     resource-class: 'docker_linux_amd64/medium+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-large-dotnet:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-large-plus-dotnet:
     resource-class: 'docker_linux_amd64/large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-extra-large-dotnet:
     resource-class: 'docker_linux_amd64/extra_large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   linux-extra-large-plus-dotnet:
     resource-class: 'docker_linux_amd64/extra_large+'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-dotnet-init-steps
   universal-large:
     resource-class: 'docker_linux_amd64/large'


### PR DESCRIPTION
Updates every remaining launch template in `launch-templates/linux.yaml` from `ubuntu22.04-node20.19-v2` (Node 20.19) to `ubuntu22.04-node24.14-v1` (Node 24.14.1, the current Node LTS) — 21 templates: all `-js`, `-jvm`, and `-dotnet` variants.

Follow-up to #133, which bumped `universal-large` (the template used by the polygraph index-repository workflow). With this change, all 22 launch templates are on the Node 24 LTS image.

`ubuntu22.04-node24.14-v1` is a published Nx Cloud workflow image (see the launch-templates image list in the Nx docs). Per the image changelog, newer images include the changes from previous ones, so this also picks up the Docker and Playwright dependency updates from the intermediate tags.

Sanity check: parsed the YAML and deep-compared against `main` — all 22 templates are on `ubuntu22.04-node24.14-v1` and no non-image fields changed.

Relates to [NXA-2215](https://linear.app/nxdev/issue/NXA-2215/update-base-image-used-by-polygraph-index-repository-to-use-current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxa-2215-update-base-image-used-by-polygraph-index-repositor-0096124d">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->